### PR TITLE
Force MAC on pod network bridge

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -896,14 +896,14 @@ function dind::create-static-routes-for-bridge {
       if [[ ${IP_MODE} = "ipv4" ]]; then
 	# Assuming pod subnets will all be /24
         dest="${POD_NET_PREFIX}${id}.0/24"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet addr" | cut -f 2 -d: | cut -f 1 -d' '`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
 	instance=$(printf "%02x" ${id})
 	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
 	  instance+="00" # Move node ID to upper byte
 	fi
 	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet6" | grep -i global | awk '{ print $3 }' | cut -f 1 -d/`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec ${node} ip route add ${dest} via ${gw}
     done
@@ -1056,7 +1056,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
-    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
+    # docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -896,14 +896,14 @@ function dind::create-static-routes-for-bridge {
       if [[ ${IP_MODE} = "ipv4" ]]; then
 	# Assuming pod subnets will all be /24
         dest="${POD_NET_PREFIX}${id}.0/24"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet addr" | cut -f 2 -d: | cut -f 1 -d' '`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
 	instance=$(printf "%02x" ${id})
 	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
 	  instance+="00" # Move node ID to upper byte
 	fi
 	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet6" | grep -i global | awk '{ print $3 }' | cut -f 1 -d/`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec ${node} ip route add ${dest} via ${gw}
     done
@@ -1056,7 +1056,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
-    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
+    # docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -896,14 +896,14 @@ function dind::create-static-routes-for-bridge {
       if [[ ${IP_MODE} = "ipv4" ]]; then
 	# Assuming pod subnets will all be /24
         dest="${POD_NET_PREFIX}${id}.0/24"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet addr" | cut -f 2 -d: | cut -f 1 -d' '`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
 	instance=$(printf "%02x" ${id})
 	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
 	  instance+="00" # Move node ID to upper byte
 	fi
 	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet6" | grep -i global | awk '{ print $3 }' | cut -f 1 -d/`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec ${node} ip route add ${dest} via ${gw}
     done
@@ -1056,7 +1056,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
-    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
+    # docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -896,14 +896,14 @@ function dind::create-static-routes-for-bridge {
       if [[ ${IP_MODE} = "ipv4" ]]; then
 	# Assuming pod subnets will all be /24
         dest="${POD_NET_PREFIX}${id}.0/24"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet addr" | cut -f 2 -d: | cut -f 1 -d' '`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
 	instance=$(printf "%02x" ${id})
 	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
 	  instance+="00" # Move node ID to upper byte
 	fi
 	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet6" | grep -i global | awk '{ print $3 }' | cut -f 1 -d/`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec ${node} ip route add ${dest} via ${gw}
     done
@@ -1056,7 +1056,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
-    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
+    # docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -896,14 +896,14 @@ function dind::create-static-routes-for-bridge {
       if [[ ${IP_MODE} = "ipv4" ]]; then
 	# Assuming pod subnets will all be /24
         dest="${POD_NET_PREFIX}${id}.0/24"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet addr" | cut -f 2 -d: | cut -f 1 -d' '`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet | awk '{ print $2 }' | sed 's,/.*,,'`
       else
 	instance=$(printf "%02x" ${id})
 	if [[ $((${POD_NET_SIZE} % 16)) -ne 0 ]]; then
 	  instance+="00" # Move node ID to upper byte
 	fi
 	dest="${POD_NET_PREFIX}${instance}::/${POD_NET_SIZE}"
-        gw=`docker exec ${dest_node} ifconfig eth0 | grep "inet6" | grep -i global | awk '{ print $3 }' | cut -f 1 -d/`
+        gw=`docker exec ${dest_node} ip addr show eth0 | grep -w inet6 | grep -i global | head -1 | awk '{ print $2 }' | sed 's,/.*,,'`
       fi
       docker exec ${node} ip route add ${dest} via ${gw}
     done
@@ -1056,7 +1056,7 @@ function dind::fix-mounts {
     if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
       docker exec "${node_name}" mount --make-shared /k8s
     fi
-    docker exec "${node_name}" mount --make-shared /sys/kernel/debug
+    # docker exec "${node_name}" mount --make-shared /sys/kernel/debug
   done
 }
 

--- a/image/20-fs.conf
+++ b/image/20-fs.conf
@@ -1,3 +1,0 @@
-[Service]
-ExecStart=
-ExecStart=/usr/local/bin/rundocker $DOCKER_EXTRA_OPTS

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -12,12 +12,30 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Some parts are taken from here:
+# https://github.com/kubernetes/test-infra/blob/master/dind/base/Dockerfile
+
+# Copyright 2017 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 # ci-xenial-systemd image source: https://github.com/errordeveloper/kubeadm-ci-dind
 # The tag includes commit id
-FROM gcr.io/kubeadm/ci-xenial-systemd:base-master-6f6ae74260bfa1b6d97251e6e0191489aeff0939
+FROM k8s.gcr.io/debian-base-amd64:0.3
+
+STOPSIGNAL SIGRTMIN+3
 
 LABEL mirantis.kubeadm_dind_cluster=1
-
 
 ENV ARCH amd64
 ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-v0.6.0.tgz
@@ -27,12 +45,51 @@ ENV CNI_SHA1=d595d3ded6499a64e8dac02466e2f5f2ce257c9f
 # (e.g. accept systemd.setenv args, etc.)
 ENV container docker
 
+ARG DEBIAN_FRONTEND=noninteractive
+RUN clean-install apt-utils \
+    apt-transport-https \
+    bash \
+    bridge-utils \
+    ca-certificates \
+    curl \
+    e2fsprogs \
+    ebtables \
+    ethtool \
+    gnupg2 \
+    ipcalc \
+    iptables \
+    iproute2 \
+    iputils-ping \
+    jq \
+    kmod \
+    lsb-core \
+    less \
+    lzma \
+    liblz4-tool \
+    mount \
+    net-tools \
+    procps \
+    socat \
+    software-properties-common \
+    util-linux \
+    vim \
+    systemd \
+    systemd-sysv \
+    sysvinit-utils
+
+# Install docker.
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && apt-key fingerprint 0EBFCD88 && add-apt-repository \
+    "deb [arch=amd64] https://download.docker.com/linux/debian \
+    $(lsb_release -cs) \
+    stable"
+RUN clean-install docker-ce=17.03.2~ce-0~debian-stretch
+
 RUN mkdir -p /hypokube /etc/systemd/system/docker.service.d /var/lib/kubelet
 
 COPY hypokube.dkr /hypokube/
 COPY kubelet.service /lib/systemd/system/
 COPY dindnet.service /lib/systemd/system/
-COPY 20-fs.conf /etc/systemd/system/docker.service.d/
+COPY docker.service /lib/systemd/system/docker.service
 COPY wrapkubeadm /usr/local/bin/
 COPY start_services /usr/local/bin/
 COPY rundocker /usr/local/bin
@@ -40,19 +97,19 @@ COPY dindnet /usr/local/bin
 COPY snapshot /usr/local/bin
 COPY kubeadm.conf.tmpl /etc/kubeadm.conf.tmpl
 
+# Remove unwanted systemd services.
 # TODO: use 'systemctl mask' to disable units
 # See here for example: https://github.com/docker/docker/issues/27202#issuecomment-253579916
-RUN apt-get -qq update && \
-    apt-mark unhold docker-engine && \
-    DEBIAN_FRONTEND=noninteractive apt-get install docker-engine=1.12.6-0~ubuntu-xenial -qqy && \
-    apt-mark hold docker-engine && \
-    DEBIAN_FRONTEND=noninteractive apt-get upgrade -qqy && \
-    DEBIAN_FRONTEND=noninteractive apt-get install bridge-utils net-tools iproute2 iputils-ping tcpdump ipcalc jq curl liblz4-tool -qqy && \
-    apt-get -qq -y autoremove && \
-    apt-get -qq clean && \
-    mkdir -p /etc/systemd/system/kubelet.service.d /etc/cni/net.d && \
-    rm -f /lib/systemd/system/multi-user.target.wants/getty.target /lib/systemd/system/sysinit.target.wants/systemd-udev* /lib/systemd/system/sockets.target.wants/systemd-udev* && \
-    chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snapshot && \
+RUN for i in /lib/systemd/system/sysinit.target.wants/*; do [ "${i##*/}" = "systemd-tmpfiles-setup.service" ] || rm -f "$i"; done; \
+  rm -f /lib/systemd/system/multi-user.target.wants/*;\
+  rm -f /etc/systemd/system/*.wants/*;\
+  rm -f /lib/systemd/system/local-fs.target.wants/*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*udev*; \
+  rm -f /lib/systemd/system/sockets.target.wants/*initctl*; \
+  rm -f /lib/systemd/system/basic.target.wants/*;\
+  rm -f /lib/systemd/system/anaconda.target.wants/*;
+
+RUN chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snapshot && \
     mkdir -p /opt/cni/bin && \
     curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/"${CNI_ARCHIVE}" >"/tmp/${CNI_ARCHIVE}" && \
       echo "${CNI_SHA1}  /tmp/${CNI_ARCHIVE}" | sha1sum -c && \
@@ -68,6 +125,5 @@ RUN apt-get -qq update && \
 
 EXPOSE 8080
 
-# TBD: update gcr.io/kubeadm/ci-xenial-systemd:base / bare
 RUN ln -fs /sbin/init /sbin/dind_init
 ENTRYPOINT ["/sbin/dind_init"]

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -38,8 +38,9 @@ STOPSIGNAL SIGRTMIN+3
 LABEL mirantis.kubeadm_dind_cluster=1
 
 ENV ARCH amd64
-ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-v0.6.0.tgz
-ENV CNI_SHA1=d595d3ded6499a64e8dac02466e2f5f2ce257c9f
+ENV CNI_VERSION=v0.7.1
+ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-"${CNI_VERSION}".tgz
+ENV CNI_SHA1=fb29e20401d3e9598a1d8e8d7992970a36de5e05
 
 # make systemd behave correctly in Docker container
 # (e.g. accept systemd.setenv args, etc.)
@@ -111,7 +112,7 @@ RUN for i in /lib/systemd/system/sysinit.target.wants/*; do [ "${i##*/}" = "syst
 
 RUN chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snapshot && \
     mkdir -p /opt/cni/bin && \
-    curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/"${CNI_ARCHIVE}" >"/tmp/${CNI_ARCHIVE}" && \
+    curl -sSL --retry 5 https://github.com/containernetworking/plugins/releases/download/"${CNI_VERSION}"/"${CNI_ARCHIVE}" >"/tmp/${CNI_ARCHIVE}" && \
       echo "${CNI_SHA1}  /tmp/${CNI_ARCHIVE}" | sha1sum -c && \
       tar -C /opt/cni/bin -xzf "/tmp/${CNI_ARCHIVE}" && \
       rm -f "/tmp/${CNI_ARCHIVE}" && \

--- a/image/dindnet
+++ b/image/dindnet
@@ -58,6 +58,7 @@ function dind::setup-config-file {
   fi
   echo "Subnet ${NETWORK}/${POD_NET_SIZE}"
   CONFIG_FILE="/etc/cni/net.d/cni.conf"
+  mkdir -p "$(dirname "${CONFIG_FILE}")"
   # NOTE: hairpin mode for CNI bridge breaks Virtlet networking,
   # to be investigated & fixed. For now, default is false for IPv4
   # and true for IPv6, unless overridden.

--- a/image/dindnet
+++ b/image/dindnet
@@ -36,13 +36,20 @@ function dind::setup-bridge {
     return  # Bridge is already set up
   fi
 
-  brctl addbr dind0
+  ip link add dind0 type bridge
   if [[ "${IP_MODE}" = "ipv6" ]]; then
     ip -6 addr add "${POD_NET_PREFIX}::1/${POD_NET_SIZE}" dev dind0
     ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
   else
     ip addr add "${POD_NET_PREFIX}.1/${POD_NET_SIZE}" dev dind0
   fi
+  # To prevent MAC on dind0 from dynamically changing, create a dummy I/F enslaved in
+  # dind0 and set the MAC of dind0 to match.
+  ip link add v1 type veth peer name v2
+  ip link set dev v1 master dind0
+  DIND0_MAC="$(ip a show v1 | grep link/ether | awk  '{ print $2; }')"
+  ip link set dev dind0 address $DIND0_MAC
+
   ip link set dind0 up
 }
 

--- a/image/docker.service
+++ b/image/docker.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=Docker Application Container Engine
+Documentation=https://docs.docker.com
+After=network-online.target docker.socket firewalld.service
+Wants=network-online.target
+Requires=docker.socket
+
+[Service]
+Environment=container=docker
+Type=notify
+# the default is not to use systemd for cgroups because the delegate issues still
+# exists and systemd currently does not support the cgroup feature set required
+# for containers run by docker
+ExecStart=/usr/local/bin/rundocker
+ExecReload=/bin/kill -s HUP $MAINPID
+LimitNOFILE=1048576
+# Having non-zero Limit*s causes performance problems due to accounting overhead
+# in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNPROC=infinity
+LimitCORE=infinity
+# Uncomment TasksMax if your systemd version supports it.
+# Only systemd 226 and above support this version.
+#TasksMax=infinity
+TimeoutStartSec=0
+# set delegate yes so that systemd does not reset the cgroups of docker containers
+Delegate=yes
+# kill only the docker process, not all processes in the cgroup
+KillMode=process
+# restart the docker process if it exits prematurely
+Restart=on-failure
+StartLimitBurst=3
+StartLimitInterval=60s
+
+[Install]
+WantedBy=multi-user.target

--- a/image/rundocker
+++ b/image/rundocker
@@ -13,10 +13,51 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Some parts are based on https://github.com/docker/docker/blob/master/hack/dind
+# Copyright 2012-2016 Docker, Inc.
+# Original version by Jerome Petazzoni <jerome@docker.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 set -o errexit
 set -o nounset
 set -o pipefail
 set -o errtrace
+
+# Ensure shared mount propagation to ensure volume mounting works for Kubernetes.
+# Took it from here:
+# https://github.com/marun/dkr-systemd-dind/blob/25702cf7a4a73bcc355a492f4e5ca96cc562a5a5/dind-setup.sh#L46
+mount --make-shared /
+
+# securityfs is mounted by systemd itself if it isn't being run in a container.
+# In case of containerized systemd, it doesn't want to have systemd mounted
+# on startup because it wants to avoid dealing with IMA in this case.
+# See https://github.com/systemd/systemd/blob/master/src/shared/ima-util.c
+# IMA stands for Integrity Measurement Architecture
+# https://sourceforge.net/p/linux-ima/wiki/Home/#integrity-measurement-architecture-ima
+# Still, we need to have securityfs in DIND for AppArmor detection and
+# support for --privileged mode, so we're mounting it there.
+if [ -d /sys/kernel/security ] && ! mountpoint -q /sys/kernel/security; then
+  mount -t securityfs none /sys/kernel/security || {
+    echo >&2 'Could not mount /sys/kernel/security.'
+    echo >&2 'AppArmor detection and --privileged mode might break.'
+  }
+fi
+
+# Mount /tmp (conditionally)
+if ! mountpoint -q /tmp; then
+  mount -t tmpfs none /tmp
+fi
 
 echo "Trying to load overlay module (this may fail)" >&2
 modprobe overlay || true


### PR DESCRIPTION
In running E2E tests, it was observed that during the testing, the MAC
on the dind0 bridge was changing. This was causing, in some cases, the
kube-dns pod to fail health checks (lose TCP communication on the bridge
for that pod).

Research shows that, if a MAC is not assigned to a virtual bridge, then
the bridge will get the lowest MAC of all enslaved interfaces (dynamically).
This implies that the MAC could also change, and in this case, if a test
pod has a lower MAC than kube-dns (which is the first pod added to the
dind0 bridge at startup), then the MAC of the bridge would change.

This does not appear to be a problem for IPv4, where the bridge has a MAC
address assigned by the CNI plugin.

With the latest CNI plugin, v0.7.1, the plugin will set the MAC for
bridges created. It will adopt existing bridges (like dind0), but will
not ensure they have a MAC.

I did try changing the sequencing of the dindnet script to first create
the CNI config, and then create the bridge, but it appears that CNI does
not get involved in the bridge creation at that time (it does later).

As a solution, this commit will create a dummy veth pair, add one of the
interfaces into the bridge, and then set the bridge's MAC to the MAC of
the interface (reading up on this indicates that we must use a MAC of an
enslaved interface).

Now, dind0 has a MAC address, and since it was explicitly set, there is no
dynamic override of the address. During E2E tests, kube-dns health check
responses make it back to the kubelet, and it no longer gets restarted.

NOTE: This commit uses CNI v0.7.1, which is found in a different repo
location. We need this newer version, as v0.6 does not have IPv6 support,
and caused other issues (like IP6tables not being set up correctly).

Fixes Mirantis issue: #127 
Fixes Kubernetes issue: #63922
