### PR TITLE
Force MAC on pod network bridge.

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -38,8 +38,9 @@ STOPSIGNAL SIGRTMIN+3
 LABEL mirantis.kubeadm_dind_cluster=1
 
 ENV ARCH amd64
-ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-v0.6.0.tgz
-ENV CNI_SHA1=d595d3ded6499a64e8dac02466e2f5f2ce257c9f
+ENV CNI_VERSION=v0.7.1
+ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-"${CNI_VERSION}".tgz
+ENV CNI_SHA1=fb29e20401d3e9598a1d8e8d7992970a36de5e05
 
 # make systemd behave correctly in Docker container
 # (e.g. accept systemd.setenv args, etc.)
@@ -111,7 +112,7 @@ RUN for i in /lib/systemd/system/sysinit.target.wants/*; do [ "${i##*/}" = "syst
 
 RUN chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snapshot && \
     mkdir -p /opt/cni/bin && \
-    curl -sSL --retry 5 https://storage.googleapis.com/kubernetes-release/network-plugins/"${CNI_ARCHIVE}" >"/tmp/${CNI_ARCHIVE}" && \
+    curl -sSL --retry 5 https://github.com/containernetworking/plugins/releases/download/"${CNI_VERSION}"/"${CNI_ARCHIVE}" >"/tmp/${CNI_ARCHIVE}" && \
       echo "${CNI_SHA1}  /tmp/${CNI_ARCHIVE}" | sha1sum -c && \
       tar -C /opt/cni/bin -xzf "/tmp/${CNI_ARCHIVE}" && \
       rm -f "/tmp/${CNI_ARCHIVE}" && \

--- a/image/dindnet
+++ b/image/dindnet
@@ -36,13 +36,20 @@ function dind::setup-bridge {
     return  # Bridge is already set up
   fi
 
-  brctl addbr dind0
+  ip link add dind0 type bridge
   if [[ "${IP_MODE}" = "ipv6" ]]; then
     ip -6 addr add "${POD_NET_PREFIX}::1/${POD_NET_SIZE}" dev dind0
     ip -6 route add ${DNS64_PREFIX_CIDR} via ${LOCAL_NAT64_SERVER}
   else
     ip addr add "${POD_NET_PREFIX}.1/${POD_NET_SIZE}" dev dind0
   fi
+  # To prevent MAC on dind0 from dynamically changing, create a dummy I/F enslaved in
+  # dind0 and set the MAC of dind0 to match.
+  ip link add v1 type veth peer name v2
+  ip link set dev v1 master dind0
+  DIND0_MAC="$(ip a show v1 | grep link/ether | awk  '{ print $2; }')"
+  ip link set dev dind0 address $DIND0_MAC
+
   ip link set dind0 up
 }
 


### PR DESCRIPTION
In running E2E tests, it was observed that during the testing, the MAC
on the dind0 bridge was changing. This was causing, in some cases, the
kube-dns pod to fail health checks (lose TCP communication on the bridge
for that pod).

Research shows that, if a MAC is not assigned to a virtual bridge, then
the bridge will get the lowest MAC of all enslaved interfaces (dynamically).
This implies that the MAC could also change, and in this case, if a test
pod has a lower MAC than kube-dns (which is the first pod added to the
dind0 bridge at startup), then the MAC of the bridge would change.

This does not appear to be a problem for IPv4, where the bridge has a MAC
address assigned by the CNI plugin.

With the latest CNI plugin, v0.7.1, the plugin will set the MAC for
bridges created. It will adopt existing bridges (like dind0), but will
not ensure they have a MAC.

I did try changing the sequencing of the dindnet script to first create
the CNI config, and then create the bridge, but it appears that CNI does
not get involved in the bridge creation at that time (it does later).

As a solution, this commit will create a dummy veth pair, add one of the
interfaces into the bridge, and then set the bridge's MAC to the MAC of
the interface (reading up on this indicates that we must use a MAC of an
enslaved interface).

Now, dind0 has a MAC address, and since it was explicitly set, there is no
dynamic override of the address. During E2E tests, kube-dns health check
responses make it back to the kubelet, and it no longer gets restarted.

NOTE: This commit uses CNI v0.7.1, which is found in a different repo
location. We need this newer version, as v0.6 does not have IPv6 support,
and caused other issues (like IP6tables not being set up correctly).

NOTE: Tested IPv4 and IPv6 on local and GCE platforms

NOTE: Was PR #135, but rebased to master.

Fixes Mirantis issue: #127
Fixes Kubernetes issue: #63922
