### PR TITLE
Find free subnet and port

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -192,8 +192,8 @@ test_multiple_clusters: &test_multiple_clusters
         name: Bring up multiple clusters in parallel
         no_output_timeout: 35m
         command: |
-          build/portforward.sh -wait 8080
-          build/portforward.sh -wait 8082
+          build/portforward.sh -wait 8080  # by default, first cluster binds to 8080
+          build/portforward.sh -wait 8081  #       ... and second cluster binds to 8081
 
           set -eu
           set -o pipefail
@@ -205,7 +205,7 @@ test_multiple_clusters: &test_multiple_clusters
             local d="./dind-cluster.sh"
 
             "${d}" up
-            APISERVER_PORT=8082 DIND_SUBNET='10.199.0.0' DIND_LABEL="$customLabel" "${d}" up
+            DIND_LABEL="$customLabel" "${d}" up
 
             # masters
             test "$(countContainersWithExactName "kube-master")" -eq 1 || {

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,19 +31,21 @@ setup: &setup
 
 display_cluster_state: &display_cluster_state
   command: |
-    build/portforward.sh -wait 8080
     kubectl="kubectl"
     if [[ ${K8S_SRC:-} ]]; then
       cd kubernetes
       kubectl="cluster/kubectl.sh"
     fi
-    "${kubectl}" version
-    "${kubectl}" get all --all-namespaces -o wide
-    "${kubectl}" get nodes
+
+    apiserver_port="$( ./dind-cluster.sh apiserver-port )"
+    build/portforward.sh -wait "$apiserver_port"
+
+    "${kubectl}" "--server=:${apiserver_port}" version
+    "${kubectl}" "--server=:${apiserver_port}" get all --all-namespaces -o wide
+    "${kubectl}" "--server=:${apiserver_port}" get nodes
 
 dump_cluster: &dump_cluster
   command: |
-    build/portforward.sh -wait 8080
     mkdir -p /tmp/cluster_state
     out="/tmp/cluster_state/dump-1.gz"
     if [[ -f ${out} ]]; then
@@ -71,7 +73,8 @@ test: &test
     - run:
         name: Bring up the cluster
         command: |
-          build/portforward.sh 8080
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER=build/portforward.sh
           ./dind-cluster.sh up
     - run:
         name: Display cluster status (1)
@@ -83,7 +86,8 @@ test: &test
     - run:
         name: Bring up the cluster (again)
         command: |
-          build/portforward.sh 8080
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER=build/portforward.sh
           ./dind-cluster.sh up
     - run:
         name: Display cluster status (2)
@@ -130,8 +134,9 @@ test_src: &test_src
         name: Bring up the cluster
         no_output_timeout: 35m
         command: |
-          build/portforward.sh -wait 8080
-          build/portforward.sh -wait 8730
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER=build/portforward.sh
+          build/portforward.sh 8730
           cd kubernetes
           ../dind-cluster.sh up
     - run:
@@ -144,16 +149,18 @@ test_src: &test_src
     - run:
         name: Bring up the cluster (again)
         command: |
-          build/portforward.sh -wait 8080
-          build/portforward.sh -wait 8730
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER=build/portforward.sh
+          build/portforward.sh 8730
           cd kubernetes
           ../dind-cluster.sh up
     - run:
         name: Run some e2e tests
         no_output_timeout: 25m
         command: |
-          build/portforward.sh -wait 8080
-          build/portforward.sh -wait 8730
+          export DIND_PORT_FORWARDER_WAIT=1
+          export DIND_PORT_FORWARDER=build/portforward.sh
+          build/portforward.sh 8730
           cd kubernetes
           ../dind-cluster.sh e2e "existing RC"
     - run:
@@ -192,9 +199,6 @@ test_multiple_clusters: &test_multiple_clusters
         name: Bring up multiple clusters in parallel
         no_output_timeout: 35m
         command: |
-          build/portforward.sh -wait 8080  # by default, first cluster binds to 8080
-          build/portforward.sh -wait 8081  #       ... and second cluster binds to 8081
-
           set -eu
           set -o pipefail
 
@@ -203,6 +207,9 @@ test_multiple_clusters: &test_multiple_clusters
             local customLabel='some.custom-label'
             local customSha='e0f1032f845a2ea6653db1f9a997ac9572d4bc65'
             local d="./dind-cluster.sh"
+
+            export DIND_PORT_FORWARDER_WAIT=1
+            export DIND_PORT_FORWARDER=build/portforward.sh
 
             "${d}" up
             DIND_LABEL="$customLabel" "${d}" up

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,18 +27,20 @@ setup: &setup
     tar -xz -C /tmp -f "/tmp/docker-${DOCKER_VERSION}.tgz"
     mv /tmp/docker/* /usr/bin
     # Start port forwarder
-    build/portforward.sh start
+    "${PWD}/build/portforward.sh" start
 
 display_cluster_state: &display_cluster_state
   command: |
+    DIND_ROOT="$PWD"
+
     kubectl="kubectl"
     if [[ ${K8S_SRC:-} ]]; then
       cd kubernetes
       kubectl="cluster/kubectl.sh"
     fi
 
-    apiserver_port="$( ./dind-cluster.sh apiserver-port )"
-    build/portforward.sh -wait "$apiserver_port"
+    apiserver_port="$( "${DIND_ROOT}/dind-cluster.sh" apiserver-port )"
+    "${DIND_ROOT}/build/portforward.sh" -wait "$apiserver_port"
 
     "${kubectl}" "--server=:${apiserver_port}" version
     "${kubectl}" "--server=:${apiserver_port}" get all --all-namespaces -o wide
@@ -74,7 +76,7 @@ test: &test
         name: Bring up the cluster
         command: |
           export DIND_PORT_FORWARDER_WAIT=1
-          export DIND_PORT_FORWARDER=build/portforward.sh
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
           ./dind-cluster.sh up
     - run:
         name: Display cluster status (1)
@@ -87,7 +89,7 @@ test: &test
         name: Bring up the cluster (again)
         command: |
           export DIND_PORT_FORWARDER_WAIT=1
-          export DIND_PORT_FORWARDER=build/portforward.sh
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
           ./dind-cluster.sh up
     - run:
         name: Display cluster status (2)
@@ -135,8 +137,8 @@ test_src: &test_src
         no_output_timeout: 35m
         command: |
           export DIND_PORT_FORWARDER_WAIT=1
-          export DIND_PORT_FORWARDER=build/portforward.sh
-          build/portforward.sh 8730
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
+          "${PWD}/build/portforward.sh" 8730
           cd kubernetes
           ../dind-cluster.sh up
     - run:
@@ -150,8 +152,8 @@ test_src: &test_src
         name: Bring up the cluster (again)
         command: |
           export DIND_PORT_FORWARDER_WAIT=1
-          export DIND_PORT_FORWARDER=build/portforward.sh
-          build/portforward.sh 8730
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
+          "${PWD}/build/portforward.sh" 8730
           cd kubernetes
           ../dind-cluster.sh up
     - run:
@@ -159,8 +161,8 @@ test_src: &test_src
         no_output_timeout: 25m
         command: |
           export DIND_PORT_FORWARDER_WAIT=1
-          export DIND_PORT_FORWARDER=build/portforward.sh
-          build/portforward.sh 8730
+          export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
+          "${PWD}/build/portforward.sh" 8730
           cd kubernetes
           ../dind-cluster.sh e2e "existing RC"
     - run:
@@ -209,7 +211,7 @@ test_multiple_clusters: &test_multiple_clusters
             local d="./dind-cluster.sh"
 
             export DIND_PORT_FORWARDER_WAIT=1
-            export DIND_PORT_FORWARDER=build/portforward.sh
+            export DIND_PORT_FORWARDER="${PWD}/build/portforward.sh"
 
             "${d}" up
             DIND_LABEL="$customLabel" "${d}" up

--- a/README.md
+++ b/README.md
@@ -225,20 +225,18 @@ The following information is currently stored in the dump:
 ## Running multiple clusters in parallel
 
 `dind-cluster.sh` can be used to create and manage multiple dind clusters.
-For the first cluster, no extra variables need to be set, but the variables listed below can optionally be configured.
+The first instance will use the default values for
+* the label
+* the subnet (and subnet mask)
+* he local port to be forwarded to the APIServer
+* ...
 
-For every additional cluster, set the following environment variables:
-
-| Environment Variable | What does it control?                                                                                                                             |
-|----------------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| DIND_LABEL           | The container label, used by `dind-cluster.sh` to label Docker resources and manage the lifecycle of the cluster's containers.                    |
-| DIND_SUBNET          | The subnet in which the cluster is placed. It must be a subnet that's not already used by the Docker engine.                                      |
-| APISERVER_PORT       | The port on the Docker host machine, that will be forwarded to the apiserver. It must not be in use by any other application on the host machine. |
+For every additional cluster, at least `DIND_LABEL` needs to be set.
 
 Example usage:
 
 ```shell
-$ APISERVER_PORT=8082 DIND_SUBNET='10.199.0.0' DIND_LABEL="example-custom-label" ./dind-cluster.sh up
+$ DIND_LABEL="example-custom-label" ./dind-cluster.sh up
 ```
 
 Example output:

--- a/build/portforward.sh
+++ b/build/portforward.sh
@@ -10,6 +10,9 @@ if [[ ${1:-} = -wait ]]; then
   wait=1
   shift
 fi
+if [ "${DIND_PORT_FORWARDER_WAIT:-}" = "1" ]; then
+  wait=1
+fi
 
 if [[ ${1:-} = start ]]; then
   docker run -d -it \

--- a/config.sh
+++ b/config.sh
@@ -1,13 +1,14 @@
 if [[ ${IP_MODE} = "ipv4" ]]; then
-    # DinD subnet (expected to be /16)
-    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+    # DIND_SUBNET="10.192.0.0"
+    # DIND_SUBNET_SIZE=16
+    :
 else
     # DinD subnet (expected to be /64)
     DIND_SUBNET="${DIND_SUBNET:-fd00:10::}"
 fi
 
 # Apiserver port
-APISERVER_PORT=${APISERVER_PORT:-8080}
+# APISERVER_PORT=${APISERVER_PORT:-8080}
 
 # Number of nodes. 0 nodes means just one master node.
 # In case of NUM_NODES=0 'node-role.kubernetes.io/master' taint is removed

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1489,13 +1489,15 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
-
-  "$fwdr" "$( dind::apiserver-port )"
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 }
 
 function dind::sha1 {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -53,26 +53,80 @@ fi
 #%CONFIG%
 
 function dind::find-free-ipv4-subnet() {
-  local allocatedNets curNet
-  allocatedNets="$(
+  local maxIP anAddressInNewSubnet
+
+  subnetSize="$1"
+
+  maxIP=$( dind::ipv4::find-maximum-claimed-ip )
+
+  # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
+  # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
+  # But, consider:
+  # maxIP: 10.0.0.255
+  # maybeNextMinHost: 10.0.1.0
+  # In the above, a subnet size of /16, will start at 10.0.0.0 - which is invalid.
+  # So we need to start the new subnet at least 32-(subnetSize) IP spaces away.
+  anAddressInNewSubnet=$(( maxIP + (1<<(32-subnetSize)) ))
+
+  # apply mask to get min host
+  nextMinHost=$(( anAddressInNewSubnet & $(dind::ipv4::netmask "$subnetSize") ))
+
+  dind::ipv4::itoa "$nextMinHost"
+}
+
+function dind::ipv4::netmask() {
+  local netmask i
+  netmask=0
+  for i in $( seq 32 $(( 32 - $1 )) )
+  do
+    netmask=$(( netmask + 2**i ))
+  done
+  echo "$netmask"
+}
+
+function dind::ipv4::find-maximum-claimed-ip() {
+  local maxIP upperIPs b m i
+  maxIP=0
+  upperIPs="$(
     docker network ls --format '{{ .Name }}' | while read -r nw
     do
-      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+      subnet="$( docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" )"
+      if [ -z "$subnet" ]
+      then
+        continue
+      fi
+      IFS='/' read -r b m <<<"$subnet"
+      echo $(( $(dind::ipv4::atoi "$b") + (1<<(32-m)) - 1 ))
     done
   )"
 
-  # this is a very naive implementations which ignores any netmask and
-  # basically assumes each net to be /16.
-  for i in $(seq 192 254) $(seq 0 191)
+  for i in $upperIPs
   do
-    curNet="10.${i}.0.0"
-    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    if [ "$(( i - maxIP ))" -gt 1 ]
     then
-      echo "$curNet"
-      return 0
+      maxIP="$i"
     fi
   done
-  return 1
+
+  echo "$maxIP"
+}
+
+function dind::ipv4::itoa() {
+  echo -n $(($(($(($(($1/256))/256))/256))%256)).
+  echo -n $(($(($(($1/256))/256))%256)).
+  echo -n $(($(($1/256))%256)).
+  echo $(($1%256))
+}
+
+function dind::ipv4::atoi() {
+  local ip="$1"
+  local ret=0
+  for (( i=0 ; i<4 ; ++i ))
+  do
+    (( ret += ${ip%%.*} * ( 256**(3-i) ) ))
+    ip=${ip#*.}
+  done
+  echo $ret
 }
 
 function dind::find-free-local-apiserver-port() {
@@ -1402,11 +1456,11 @@ function dind::node-ip {
 function dind::get-ip-from-range() {
   local idx="$1"
 
-  read -r range _ <<<"$( dind::get-subnet )"
+  read -r net _ <<<"$( dind::get-subnet )"
+  ipNum="$( dind::ipv4::atoi "$net" )"
+  ipNum=$(( ipNum + idx ))
 
-  printf '%s.%s\n' \
-    "$( echo "$range" | cut -d. -f1-3 )" \
-    "$idx"
+  dind::ipv4::itoa "$ipNum"
 }
 
 function dind::get-subnet {
@@ -1421,8 +1475,8 @@ function dind::get-subnet {
 
   if [ "$netDataErr" -ne 0 ]
   then
-    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet)}"
     mask="${DIND_SUBNET_SIZE:-16}"
+    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet "$mask")}"
     exists=0
   else
     IFS=/ read -r net mask <<<"$netData"

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -118,10 +118,10 @@ function dind::ipv4::find-maximum-claimed-ip() {
 }
 
 function dind::ipv4::itoa() {
-  echo -n $(($(($(($(($1/256))/256))/256))%256)).
-  echo -n $(($(($(($1/256))/256))%256)).
-  echo -n $(($(($1/256))%256)).
-  echo $(($1%256))
+  echo -n $(( ($1 / 256 / 256 / 256) % 256)).
+  echo -n $(( ($1 / 256 / 256) % 256 )).
+  echo -n $(( ($1 / 256) % 256 )).
+  echo    $((  $1 % 256 ))
 }
 
 function dind::ipv4::atoi() {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -135,12 +135,21 @@ function dind::ipv4::atoi() {
   echo $ret
 }
 
+function dind::localhost() {
+  if [[ ${IP_MODE} = "ipv6" ]]; then
+    echo '[::1]'
+  else
+    echo '127.0.0.1'
+  fi
+}
+
 function dind::find-free-local-apiserver-port() {
-  local port rc
+  local port rc local_host
+  local_host="$( dind::localhost )"
   for port in $(seq 8080 9090)
   do
     set +e
-    ( echo "" >"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+    ( echo "" >"/dev/tcp/${local_host}/${port}" ) >/dev/null 2>&1
     rc=$?
     set -e
     if [ $rc -ne 0 ]
@@ -907,13 +916,10 @@ function dind::kubeadm-version {
 function dind::init {
   local -a opts
   dind::set-master-opts
-  local local_host="127.0.0.1"
-  if [[ ${IP_MODE} = "ipv6" ]]; then
-      local_host="[::1]"
-  fi
-  local master_name container_id
+  local local_host master_name container_id
   master_name="$(dind::master-name)"
-  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
+  local_host="$( dind::localhost )"
+  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 "${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT}" ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -1216,10 +1222,9 @@ function dind::wait-for-ready {
   echo "[done]" >&2
 
   dind::retry "${kubectl}" --context "$ctx" get nodes >&2
-  local_host="localhost"
-  if [[ ${IP_MODE} = "ipv6" ]]; then
-      local_host="[::1]"
-  fi
+
+  local local_host
+  local_host="$( dind::localhost )"
   dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
@@ -1346,20 +1351,17 @@ function dind::restore_container {
 }
 
 function dind::restore {
-  local apiserver_port local_host containter_id pid pids
+  local apiserver_port local_host pid pids
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
+  local_host="$( dind::localhost )"
   apiserver_port="$( dind::apiserver-port )"
   for ((n=0; n <= NUM_NODES; n++)); do
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        local_host="127.0.0.1"
-        if [[ ${IP_MODE} = "ipv6" ]]; then
-          local_host="[::1]"
-        fi
-        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 "${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT}" ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -143,6 +143,21 @@ function dind::localhost() {
   fi
 }
 
+function dind::find-free-remote-apiserver-port() {
+  local port local_host
+
+  local_host="$( dind::localhost )"
+  for port in $(seq 8080 9090)
+  do
+    if docker run -p "${local_host}:${port}:8080" --entrypoint /bin/true "${DIND_IMAGE}" >/dev/null 2>&1
+    then
+      echo "$port"
+      return 0
+    fi
+  done
+  return 1
+}
+
 function dind::find-free-local-apiserver-port() {
   local port rc local_host
   local_host="$( dind::localhost )"
@@ -1423,7 +1438,7 @@ function dind::apiserver-port {
   fi
 
   # get a random free port
-  APISERVER_PORT="$(dind::find-free-local-apiserver-port)"
+  APISERVER_PORT="$(dind::find-free-remote-apiserver-port)"
   echo "$APISERVER_PORT"
 }
 

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -52,6 +52,44 @@ fi
 
 #%CONFIG%
 
+function dind::find-free-ipv4-subnet() {
+  local allocatedNets curNet
+  allocatedNets="$(
+    docker network ls --format '{{ .Name }}' | while read -r nw
+    do
+      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+    done
+  )"
+
+  # this is a very naive implementations which ignores any netmask and
+  # basically assumes each net to be /16.
+  for i in $(seq 192 254) $(seq 0 191)
+  do
+    curNet="10.${i}.0.0"
+    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    then
+      echo "$curNet"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function dind::find-free-local-apiserver-port() {
+  local port rc
+  for port in $(seq 8080 9090)
+  do
+    set +e
+    ( echo "" >"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+        echo "$port";
+        return 0;
+    fi
+  done
+}
+
 IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
@@ -81,11 +119,22 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
 	exit 1
     fi
 else
-    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+    if [ -z "${DIND_SUBNET_SIZE:-}" ] && [ -z "${DIND_SUBNET:-}" ]
+    then
+      DIND_SUBNET_SIZE=16
+      DIND_SUBNET="$( dind::find-free-ipv4-subnet )"
+    else
+      if [ -z "${DIND_SUBNET_SIZE:-}" ] || [ -z "${DIND_SUBNET}" ]
+      then
+        # shellcheck disable=SC2016
+        echo 'You need to set either both $DIND_SUBENT & $DIND_SUBNET_SIZE or none' >&2
+        exit 3
+      fi
+    fi
+
     dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/0$//')"
     KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-127.0.0.1}"
     SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
-    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-16}"
     dns_server="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
     DEFAULT_POD_NETWORK_CIDR="10.244.0.0/16"
     USE_HAIRPIN="${USE_HAIRPIN:-false}"  # Disabled for IPv4, as issue with Virtlet networking
@@ -176,7 +225,7 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=8080}"
+: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -490,13 +539,20 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect $(dind::net-name) >&/dev/null; then
+  local netName
+  netName="$(dind::net-name)"
+
+  if ! docker network inspect "${netName}" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" $(dind::net-name) >/dev/null
+    docker network create \
+      ${v6settings} \
+      --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" \
+      --gateway="${dind_ip_base}1" \
+      "${netName}" >/dev/null
   fi
 }
 

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1492,12 +1492,16 @@ function dind::start-port-forwarder {
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
+
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -143,39 +143,6 @@ function dind::localhost() {
   fi
 }
 
-function dind::find-free-remote-apiserver-port() {
-  local port local_host
-
-  local_host="$( dind::localhost )"
-  for port in $(seq 8080 9090)
-  do
-    if docker run -p "${local_host}:${port}:8080" --entrypoint /bin/true "${DIND_IMAGE}" >/dev/null 2>&1
-    then
-      echo "$port"
-      return 0
-    fi
-  done
-  return 1
-}
-
-function dind::find-free-local-apiserver-port() {
-  local port rc local_host
-  local_host="$( dind::localhost )"
-  for port in $(seq 8080 9090)
-  do
-    set +e
-    ( echo "" >"/dev/tcp/${local_host}/${port}" ) >/dev/null 2>&1
-    rc=$?
-    set -e
-    if [ $rc -ne 0 ]
-    then
-      echo "$port"
-      return 0
-    fi
-  done
-  return 1
-}
-
 IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
@@ -1025,6 +992,7 @@ EOF
   fi
   kubeadm_join_flags="$(dind::kubeadm "${container_id}" init "${init_args[@]}" --skip-preflight-checks "$@" | grep '^ *kubeadm join' | sed 's/^ *kubeadm join //')"
   dind::configure-kubectl
+  dind::start-port-forwarder
 }
 
 function dind::create-node-container {
@@ -1402,6 +1370,7 @@ function dind::restore {
   # Recheck kubectl config. It's possible that the cluster was started
   # on this docker from different host
   dind::configure-kubectl
+  dind::start-port-forwarder
   dind::wait-for-ready
 }
 
@@ -1438,7 +1407,7 @@ function dind::apiserver-port {
   fi
 
   # get a random free port
-  APISERVER_PORT="$(dind::find-free-remote-apiserver-port)"
+  APISERVER_PORT=0
   echo "$APISERVER_PORT"
 }
 
@@ -1517,6 +1486,16 @@ function dind::remove-volumes {
     dind::step "Removing volume:" "${volume_id}"
     docker volume rm "${volume_id}"
   done
+}
+
+function dind::start-port-forwarder {
+  local fwdr
+  fwdr="${DIND_PORT_FORWARDER:-}"
+
+  [ -n "$fwdr" ] || return 0
+  [ -x "$fwdr" ] || return 0
+
+  "$fwdr" "$( dind::apiserver-port )"
 }
 
 function dind::sha1 {
@@ -1854,6 +1833,9 @@ case "${1:-}" in
     ;;
   split-dump64)
     dind::split-dump64
+    ;;
+  apiserver-port)
+    dind::apiserver-port
     ;;
   *)
     echo "usage:" >&2

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1489,19 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  set -x
-
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
 
-  set +x
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -52,6 +52,44 @@ fi
 
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:stable
 
+function dind::find-free-ipv4-subnet() {
+  local allocatedNets curNet
+  allocatedNets="$(
+    docker network ls --format '{{ .Name }}' | while read -r nw
+    do
+      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+    done
+  )"
+
+  # this is a very naive implementations which ignores any netmask and
+  # basically assumes each net to be /16.
+  for i in $(seq 192 254) $(seq 0 191)
+  do
+    curNet="10.${i}.0.0"
+    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    then
+      echo "$curNet"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function dind::find-free-local-apiserver-port() {
+  local port rc
+  for port in $(seq 8080 9090)
+  do
+    set +e
+    ( echo "" >"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+        echo "$port";
+        return 0;
+    fi
+  done
+}
+
 IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
@@ -81,11 +119,22 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
 	exit 1
     fi
 else
-    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+    if [ -z "${DIND_SUBNET_SIZE:-}" ] && [ -z "${DIND_SUBNET:-}" ]
+    then
+      DIND_SUBNET_SIZE=16
+      DIND_SUBNET="$( dind::find-free-ipv4-subnet )"
+    else
+      if [ -z "${DIND_SUBNET_SIZE:-}" ] || [ -z "${DIND_SUBNET}" ]
+      then
+        # shellcheck disable=SC2016
+        echo 'You need to set either both $DIND_SUBENT & $DIND_SUBNET_SIZE or none' >&2
+        exit 3
+      fi
+    fi
+
     dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/0$//')"
     KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-127.0.0.1}"
     SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
-    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-16}"
     dns_server="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
     DEFAULT_POD_NETWORK_CIDR="10.244.0.0/16"
     USE_HAIRPIN="${USE_HAIRPIN:-false}"  # Disabled for IPv4, as issue with Virtlet networking
@@ -176,7 +225,7 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=8080}"
+: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -490,13 +539,20 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect $(dind::net-name) >&/dev/null; then
+  local netName
+  netName="$(dind::net-name)"
+
+  if ! docker network inspect "${netName}" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" $(dind::net-name) >/dev/null
+    docker network create \
+      ${v6settings} \
+      --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" \
+      --gateway="${dind_ip_base}1" \
+      "${netName}" >/dev/null
   fi
 }
 

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -53,26 +53,80 @@ fi
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:stable
 
 function dind::find-free-ipv4-subnet() {
-  local allocatedNets curNet
-  allocatedNets="$(
+  local maxIP anAddressInNewSubnet
+
+  subnetSize="$1"
+
+  maxIP=$( dind::ipv4::find-maximum-claimed-ip )
+
+  # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
+  # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
+  # But, consider:
+  # maxIP: 10.0.0.255
+  # maybeNextMinHost: 10.0.1.0
+  # In the above, a subnet size of /16, will start at 10.0.0.0 - which is invalid.
+  # So we need to start the new subnet at least 32-(subnetSize) IP spaces away.
+  anAddressInNewSubnet=$(( maxIP + (1<<(32-subnetSize)) ))
+
+  # apply mask to get min host
+  nextMinHost=$(( anAddressInNewSubnet & $(dind::ipv4::netmask "$subnetSize") ))
+
+  dind::ipv4::itoa "$nextMinHost"
+}
+
+function dind::ipv4::netmask() {
+  local netmask i
+  netmask=0
+  for i in $( seq 32 $(( 32 - $1 )) )
+  do
+    netmask=$(( netmask + 2**i ))
+  done
+  echo "$netmask"
+}
+
+function dind::ipv4::find-maximum-claimed-ip() {
+  local maxIP upperIPs b m i
+  maxIP=0
+  upperIPs="$(
     docker network ls --format '{{ .Name }}' | while read -r nw
     do
-      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+      subnet="$( docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" )"
+      if [ -z "$subnet" ]
+      then
+        continue
+      fi
+      IFS='/' read -r b m <<<"$subnet"
+      echo $(( $(dind::ipv4::atoi "$b") + (1<<(32-m)) - 1 ))
     done
   )"
 
-  # this is a very naive implementations which ignores any netmask and
-  # basically assumes each net to be /16.
-  for i in $(seq 192 254) $(seq 0 191)
+  for i in $upperIPs
   do
-    curNet="10.${i}.0.0"
-    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    if [ "$(( i - maxIP ))" -gt 1 ]
     then
-      echo "$curNet"
-      return 0
+      maxIP="$i"
     fi
   done
-  return 1
+
+  echo "$maxIP"
+}
+
+function dind::ipv4::itoa() {
+  echo -n $(($(($(($(($1/256))/256))/256))%256)).
+  echo -n $(($(($(($1/256))/256))%256)).
+  echo -n $(($(($1/256))%256)).
+  echo $(($1%256))
+}
+
+function dind::ipv4::atoi() {
+  local ip="$1"
+  local ret=0
+  for (( i=0 ; i<4 ; ++i ))
+  do
+    (( ret += ${ip%%.*} * ( 256**(3-i) ) ))
+    ip=${ip#*.}
+  done
+  echo $ret
 }
 
 function dind::find-free-local-apiserver-port() {
@@ -212,7 +266,6 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -775,7 +828,7 @@ function dind::configure-kubectl {
   context_name="$(dind::context-name)"
   cluster_name="$(dind::context-name)"
   "${kubectl}" config set-cluster "$cluster_name" \
-    --server="http://${host}:${APISERVER_PORT}" \
+    --server="http://${host}:$(dind::apiserver-port)" \
     --insecure-skip-tls-verify=true
   "${kubectl}" config set-context "$context_name" --cluster="$cluster_name"
 }
@@ -854,7 +907,7 @@ function dind::init {
   fi
   local master_name container_id
   master_name="$(dind::master-name)"
-  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
+  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -1161,7 +1214,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
+  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {
@@ -1287,18 +1340,20 @@ function dind::restore_container {
 }
 
 function dind::restore {
+  local apiserver_port local_host containter_id pid pids
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
+  apiserver_port="$( dind::apiserver-port )"
   for ((n=0; n <= NUM_NODES; n++)); do
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        local local_host="127.0.0.1"
+        local_host="127.0.0.1"
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -1339,6 +1394,31 @@ function dind::down {
   fi
 }
 
+function dind::apiserver-port {
+  # APISERVER_PORT is explicitely set
+  if [ -n "${APISERVER_PORT:-}" ]
+  then
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # Get the port from the master
+  local master port
+  master="$(dind::master-name)"
+  # 8080/tcp -> 127.0.0.1:8082  =>  8082
+  port="$( docker port "$master" 2>/dev/null | awk -F: "/^${INTERNAL_APISERVER_PORT}/{ print \$NF }" )"
+  if [ -n "$port" ]
+  then
+    APISERVER_PORT="$port"
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # get a random free port
+  APISERVER_PORT="$(dind::find-free-local-apiserver-port)"
+  echo "$APISERVER_PORT"
+}
+
 function dind::master-name {
   echo "kube-master$( dind::clusterSuffix )"
 }
@@ -1376,11 +1456,11 @@ function dind::node-ip {
 function dind::get-ip-from-range() {
   local idx="$1"
 
-  read -r range _ <<<"$( dind::get-subnet )"
+  read -r net _ <<<"$( dind::get-subnet )"
+  ipNum="$( dind::ipv4::atoi "$net" )"
+  ipNum=$(( ipNum + idx ))
 
-  printf '%s.%s\n' \
-    "$( echo "$range" | cut -d. -f1-3 )" \
-    "$idx"
+  dind::ipv4::itoa "$ipNum"
 }
 
 function dind::get-subnet {
@@ -1395,8 +1475,8 @@ function dind::get-subnet {
 
   if [ "$netDataErr" -ne 0 ]
   then
-    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet)}"
     mask="${DIND_SUBNET_SIZE:-16}"
+    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet "$mask")}"
     exists=0
   else
     IFS=/ read -r net mask <<<"$netData"

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1489,13 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  set -x
+
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 
-  "$fwdr" "$( dind::apiserver-port )"
+  set +x
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1489,19 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  set -x
-
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
 
-  set +x
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -53,26 +53,80 @@ fi
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:v1.10
 
 function dind::find-free-ipv4-subnet() {
-  local allocatedNets curNet
-  allocatedNets="$(
+  local maxIP anAddressInNewSubnet
+
+  subnetSize="$1"
+
+  maxIP=$( dind::ipv4::find-maximum-claimed-ip )
+
+  # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
+  # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
+  # But, consider:
+  # maxIP: 10.0.0.255
+  # maybeNextMinHost: 10.0.1.0
+  # In the above, a subnet size of /16, will start at 10.0.0.0 - which is invalid.
+  # So we need to start the new subnet at least 32-(subnetSize) IP spaces away.
+  anAddressInNewSubnet=$(( maxIP + (1<<(32-subnetSize)) ))
+
+  # apply mask to get min host
+  nextMinHost=$(( anAddressInNewSubnet & $(dind::ipv4::netmask "$subnetSize") ))
+
+  dind::ipv4::itoa "$nextMinHost"
+}
+
+function dind::ipv4::netmask() {
+  local netmask i
+  netmask=0
+  for i in $( seq 32 $(( 32 - $1 )) )
+  do
+    netmask=$(( netmask + 2**i ))
+  done
+  echo "$netmask"
+}
+
+function dind::ipv4::find-maximum-claimed-ip() {
+  local maxIP upperIPs b m i
+  maxIP=0
+  upperIPs="$(
     docker network ls --format '{{ .Name }}' | while read -r nw
     do
-      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+      subnet="$( docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" )"
+      if [ -z "$subnet" ]
+      then
+        continue
+      fi
+      IFS='/' read -r b m <<<"$subnet"
+      echo $(( $(dind::ipv4::atoi "$b") + (1<<(32-m)) - 1 ))
     done
   )"
 
-  # this is a very naive implementations which ignores any netmask and
-  # basically assumes each net to be /16.
-  for i in $(seq 192 254) $(seq 0 191)
+  for i in $upperIPs
   do
-    curNet="10.${i}.0.0"
-    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    if [ "$(( i - maxIP ))" -gt 1 ]
     then
-      echo "$curNet"
-      return 0
+      maxIP="$i"
     fi
   done
-  return 1
+
+  echo "$maxIP"
+}
+
+function dind::ipv4::itoa() {
+  echo -n $(($(($(($(($1/256))/256))/256))%256)).
+  echo -n $(($(($(($1/256))/256))%256)).
+  echo -n $(($(($1/256))%256)).
+  echo $(($1%256))
+}
+
+function dind::ipv4::atoi() {
+  local ip="$1"
+  local ret=0
+  for (( i=0 ; i<4 ; ++i ))
+  do
+    (( ret += ${ip%%.*} * ( 256**(3-i) ) ))
+    ip=${ip#*.}
+  done
+  echo $ret
 }
 
 function dind::find-free-local-apiserver-port() {
@@ -212,7 +266,6 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -775,7 +828,7 @@ function dind::configure-kubectl {
   context_name="$(dind::context-name)"
   cluster_name="$(dind::context-name)"
   "${kubectl}" config set-cluster "$cluster_name" \
-    --server="http://${host}:${APISERVER_PORT}" \
+    --server="http://${host}:$(dind::apiserver-port)" \
     --insecure-skip-tls-verify=true
   "${kubectl}" config set-context "$context_name" --cluster="$cluster_name"
 }
@@ -854,7 +907,7 @@ function dind::init {
   fi
   local master_name container_id
   master_name="$(dind::master-name)"
-  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
+  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -1161,7 +1214,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
+  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {
@@ -1287,18 +1340,20 @@ function dind::restore_container {
 }
 
 function dind::restore {
+  local apiserver_port local_host containter_id pid pids
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
+  apiserver_port="$( dind::apiserver-port )"
   for ((n=0; n <= NUM_NODES; n++)); do
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        local local_host="127.0.0.1"
+        local_host="127.0.0.1"
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -1339,6 +1394,31 @@ function dind::down {
   fi
 }
 
+function dind::apiserver-port {
+  # APISERVER_PORT is explicitely set
+  if [ -n "${APISERVER_PORT:-}" ]
+  then
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # Get the port from the master
+  local master port
+  master="$(dind::master-name)"
+  # 8080/tcp -> 127.0.0.1:8082  =>  8082
+  port="$( docker port "$master" 2>/dev/null | awk -F: "/^${INTERNAL_APISERVER_PORT}/{ print \$NF }" )"
+  if [ -n "$port" ]
+  then
+    APISERVER_PORT="$port"
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # get a random free port
+  APISERVER_PORT="$(dind::find-free-local-apiserver-port)"
+  echo "$APISERVER_PORT"
+}
+
 function dind::master-name {
   echo "kube-master$( dind::clusterSuffix )"
 }
@@ -1376,11 +1456,11 @@ function dind::node-ip {
 function dind::get-ip-from-range() {
   local idx="$1"
 
-  read -r range _ <<<"$( dind::get-subnet )"
+  read -r net _ <<<"$( dind::get-subnet )"
+  ipNum="$( dind::ipv4::atoi "$net" )"
+  ipNum=$(( ipNum + idx ))
 
-  printf '%s.%s\n' \
-    "$( echo "$range" | cut -d. -f1-3 )" \
-    "$idx"
+  dind::ipv4::itoa "$ipNum"
 }
 
 function dind::get-subnet {
@@ -1395,8 +1475,8 @@ function dind::get-subnet {
 
   if [ "$netDataErr" -ne 0 ]
   then
-    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet)}"
     mask="${DIND_SUBNET_SIZE:-16}"
+    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet "$mask")}"
     exists=0
   else
     IFS=/ read -r net mask <<<"$netData"

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1489,13 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  set -x
+
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 
-  "$fwdr" "$( dind::apiserver-port )"
+  set +x
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -52,6 +52,44 @@ fi
 
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:v1.10
 
+function dind::find-free-ipv4-subnet() {
+  local allocatedNets curNet
+  allocatedNets="$(
+    docker network ls --format '{{ .Name }}' | while read -r nw
+    do
+      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+    done
+  )"
+
+  # this is a very naive implementations which ignores any netmask and
+  # basically assumes each net to be /16.
+  for i in $(seq 192 254) $(seq 0 191)
+  do
+    curNet="10.${i}.0.0"
+    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    then
+      echo "$curNet"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function dind::find-free-local-apiserver-port() {
+  local port rc
+  for port in $(seq 8080 9090)
+  do
+    set +e
+    ( echo "" >"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+        echo "$port";
+        return 0;
+    fi
+  done
+}
+
 IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
@@ -81,11 +119,22 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
 	exit 1
     fi
 else
-    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+    if [ -z "${DIND_SUBNET_SIZE:-}" ] && [ -z "${DIND_SUBNET:-}" ]
+    then
+      DIND_SUBNET_SIZE=16
+      DIND_SUBNET="$( dind::find-free-ipv4-subnet )"
+    else
+      if [ -z "${DIND_SUBNET_SIZE:-}" ] || [ -z "${DIND_SUBNET}" ]
+      then
+        # shellcheck disable=SC2016
+        echo 'You need to set either both $DIND_SUBENT & $DIND_SUBNET_SIZE or none' >&2
+        exit 3
+      fi
+    fi
+
     dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/0$//')"
     KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-127.0.0.1}"
     SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
-    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-16}"
     dns_server="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
     DEFAULT_POD_NETWORK_CIDR="10.244.0.0/16"
     USE_HAIRPIN="${USE_HAIRPIN:-false}"  # Disabled for IPv4, as issue with Virtlet networking
@@ -176,7 +225,7 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=8080}"
+: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -490,13 +539,20 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect $(dind::net-name) >&/dev/null; then
+  local netName
+  netName="$(dind::net-name)"
+
+  if ! docker network inspect "${netName}" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" $(dind::net-name) >/dev/null
+    docker network create \
+      ${v6settings} \
+      --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" \
+      --gateway="${dind_ip_base}1" \
+      "${netName}" >/dev/null
   fi
 }
 

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1489,19 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  set -x
-
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
 
-  set +x
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1489,13 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  set -x
+
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 
-  "$fwdr" "$( dind::apiserver-port )"
+  set +x
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -53,26 +53,80 @@ fi
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:v1.11
 
 function dind::find-free-ipv4-subnet() {
-  local allocatedNets curNet
-  allocatedNets="$(
+  local maxIP anAddressInNewSubnet
+
+  subnetSize="$1"
+
+  maxIP=$( dind::ipv4::find-maximum-claimed-ip )
+
+  # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
+  # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
+  # But, consider:
+  # maxIP: 10.0.0.255
+  # maybeNextMinHost: 10.0.1.0
+  # In the above, a subnet size of /16, will start at 10.0.0.0 - which is invalid.
+  # So we need to start the new subnet at least 32-(subnetSize) IP spaces away.
+  anAddressInNewSubnet=$(( maxIP + (1<<(32-subnetSize)) ))
+
+  # apply mask to get min host
+  nextMinHost=$(( anAddressInNewSubnet & $(dind::ipv4::netmask "$subnetSize") ))
+
+  dind::ipv4::itoa "$nextMinHost"
+}
+
+function dind::ipv4::netmask() {
+  local netmask i
+  netmask=0
+  for i in $( seq 32 $(( 32 - $1 )) )
+  do
+    netmask=$(( netmask + 2**i ))
+  done
+  echo "$netmask"
+}
+
+function dind::ipv4::find-maximum-claimed-ip() {
+  local maxIP upperIPs b m i
+  maxIP=0
+  upperIPs="$(
     docker network ls --format '{{ .Name }}' | while read -r nw
     do
-      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+      subnet="$( docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" )"
+      if [ -z "$subnet" ]
+      then
+        continue
+      fi
+      IFS='/' read -r b m <<<"$subnet"
+      echo $(( $(dind::ipv4::atoi "$b") + (1<<(32-m)) - 1 ))
     done
   )"
 
-  # this is a very naive implementations which ignores any netmask and
-  # basically assumes each net to be /16.
-  for i in $(seq 192 254) $(seq 0 191)
+  for i in $upperIPs
   do
-    curNet="10.${i}.0.0"
-    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    if [ "$(( i - maxIP ))" -gt 1 ]
     then
-      echo "$curNet"
-      return 0
+      maxIP="$i"
     fi
   done
-  return 1
+
+  echo "$maxIP"
+}
+
+function dind::ipv4::itoa() {
+  echo -n $(($(($(($(($1/256))/256))/256))%256)).
+  echo -n $(($(($(($1/256))/256))%256)).
+  echo -n $(($(($1/256))%256)).
+  echo $(($1%256))
+}
+
+function dind::ipv4::atoi() {
+  local ip="$1"
+  local ret=0
+  for (( i=0 ; i<4 ; ++i ))
+  do
+    (( ret += ${ip%%.*} * ( 256**(3-i) ) ))
+    ip=${ip#*.}
+  done
+  echo $ret
 }
 
 function dind::find-free-local-apiserver-port() {
@@ -212,7 +266,6 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -775,7 +828,7 @@ function dind::configure-kubectl {
   context_name="$(dind::context-name)"
   cluster_name="$(dind::context-name)"
   "${kubectl}" config set-cluster "$cluster_name" \
-    --server="http://${host}:${APISERVER_PORT}" \
+    --server="http://${host}:$(dind::apiserver-port)" \
     --insecure-skip-tls-verify=true
   "${kubectl}" config set-context "$context_name" --cluster="$cluster_name"
 }
@@ -854,7 +907,7 @@ function dind::init {
   fi
   local master_name container_id
   master_name="$(dind::master-name)"
-  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
+  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -1161,7 +1214,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
+  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {
@@ -1287,18 +1340,20 @@ function dind::restore_container {
 }
 
 function dind::restore {
+  local apiserver_port local_host containter_id pid pids
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
+  apiserver_port="$( dind::apiserver-port )"
   for ((n=0; n <= NUM_NODES; n++)); do
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        local local_host="127.0.0.1"
+        local_host="127.0.0.1"
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -1339,6 +1394,31 @@ function dind::down {
   fi
 }
 
+function dind::apiserver-port {
+  # APISERVER_PORT is explicitely set
+  if [ -n "${APISERVER_PORT:-}" ]
+  then
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # Get the port from the master
+  local master port
+  master="$(dind::master-name)"
+  # 8080/tcp -> 127.0.0.1:8082  =>  8082
+  port="$( docker port "$master" 2>/dev/null | awk -F: "/^${INTERNAL_APISERVER_PORT}/{ print \$NF }" )"
+  if [ -n "$port" ]
+  then
+    APISERVER_PORT="$port"
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # get a random free port
+  APISERVER_PORT="$(dind::find-free-local-apiserver-port)"
+  echo "$APISERVER_PORT"
+}
+
 function dind::master-name {
   echo "kube-master$( dind::clusterSuffix )"
 }
@@ -1376,11 +1456,11 @@ function dind::node-ip {
 function dind::get-ip-from-range() {
   local idx="$1"
 
-  read -r range _ <<<"$( dind::get-subnet )"
+  read -r net _ <<<"$( dind::get-subnet )"
+  ipNum="$( dind::ipv4::atoi "$net" )"
+  ipNum=$(( ipNum + idx ))
 
-  printf '%s.%s\n' \
-    "$( echo "$range" | cut -d. -f1-3 )" \
-    "$idx"
+  dind::ipv4::itoa "$ipNum"
 }
 
 function dind::get-subnet {
@@ -1395,8 +1475,8 @@ function dind::get-subnet {
 
   if [ "$netDataErr" -ne 0 ]
   then
-    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet)}"
     mask="${DIND_SUBNET_SIZE:-16}"
+    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet "$mask")}"
     exists=0
   else
     IFS=/ read -r net mask <<<"$netData"

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -1489,19 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  set -x
-
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
 
-  set +x
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -1489,13 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  set -x
+
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 
-  "$fwdr" "$( dind::apiserver-port )"
+  set +x
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -52,6 +52,44 @@ fi
 
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:v1.8
 
+function dind::find-free-ipv4-subnet() {
+  local allocatedNets curNet
+  allocatedNets="$(
+    docker network ls --format '{{ .Name }}' | while read -r nw
+    do
+      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+    done
+  )"
+
+  # this is a very naive implementations which ignores any netmask and
+  # basically assumes each net to be /16.
+  for i in $(seq 192 254) $(seq 0 191)
+  do
+    curNet="10.${i}.0.0"
+    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    then
+      echo "$curNet"
+      return 0
+    fi
+  done
+  return 1
+}
+
+function dind::find-free-local-apiserver-port() {
+  local port rc
+  for port in $(seq 8080 9090)
+  do
+    set +e
+    ( echo "" >"/dev/tcp/127.0.0.1/${port}" ) >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [ $rc -ne 0 ]; then
+        echo "$port";
+        return 0;
+    fi
+  done
+}
+
 IP_MODE="${IP_MODE:-ipv4}"  # ipv4, ipv6, (future) dualstack
 if [[ ! ${EMBEDDED_CONFIG:-} ]]; then
   source "${DIND_ROOT}/config.sh"
@@ -81,11 +119,22 @@ if [[ ${IP_MODE} = "ipv6" ]]; then
 	exit 1
     fi
 else
-    DIND_SUBNET="${DIND_SUBNET:-10.192.0.0}"
+    if [ -z "${DIND_SUBNET_SIZE:-}" ] && [ -z "${DIND_SUBNET:-}" ]
+    then
+      DIND_SUBNET_SIZE=16
+      DIND_SUBNET="$( dind::find-free-ipv4-subnet )"
+    else
+      if [ -z "${DIND_SUBNET_SIZE:-}" ] || [ -z "${DIND_SUBNET}" ]
+      then
+        # shellcheck disable=SC2016
+        echo 'You need to set either both $DIND_SUBENT & $DIND_SUBNET_SIZE or none' >&2
+        exit 3
+      fi
+    fi
+
     dind_ip_base="$(echo "${DIND_SUBNET}" | sed 's/0$//')"
     KUBE_RSYNC_ADDR="${KUBE_RSYNC_ADDR:-127.0.0.1}"
     SERVICE_CIDR="${SERVICE_CIDR:-10.96.0.0/12}"
-    DIND_SUBNET_SIZE="${DIND_SUBNET_SIZE:-16}"
     dns_server="${REMOTE_DNS64_V4SERVER:-8.8.8.8}"
     DEFAULT_POD_NETWORK_CIDR="10.244.0.0/16"
     USE_HAIRPIN="${USE_HAIRPIN:-false}"  # Disabled for IPv4, as issue with Virtlet networking
@@ -176,7 +225,7 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=8080}"
+: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -490,13 +539,20 @@ function dind::ensure-binaries {
 }
 
 function dind::ensure-network {
-  if ! docker network inspect $(dind::net-name) >&/dev/null; then
+  local netName
+  netName="$(dind::net-name)"
+
+  if ! docker network inspect "${netName}" >&/dev/null; then
     local v6settings=""
     if [[ ${IP_MODE} = "ipv6" ]]; then
       # Need second network for NAT64
       v6settings="--subnet=172.18.0.0/16 --ipv6"
     fi
-    docker network create ${v6settings} --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" --gateway="${dind_ip_base}1" $(dind::net-name) >/dev/null
+    docker network create \
+      ${v6settings} \
+      --subnet="${DIND_SUBNET}/${DIND_SUBNET_SIZE}" \
+      --gateway="${dind_ip_base}1" \
+      "${netName}" >/dev/null
   fi
 }
 

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1489,19 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  set -x
-
   local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
-  then
-    port="$( dind::apiserver-port )"
-    dind::step "+ Setting up port-forwarding for :${port}"
-    "$fwdr" "$port"
-  fi
+  [ -n "$fwdr" ] || return 0
 
-  set +x
+  [ -x "$fwdr" ] || {
+    echo "'${fwdr}' is not executable." >&2
+    return 1
+  }
+
+  port="$( dind::apiserver-port )"
+  dind::step "+ Setting up port-forwarding for :${port}"
+  "$fwdr" "$port"
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -53,26 +53,80 @@ fi
 EMBEDDED_CONFIG=y;DIND_IMAGE=mirantis/kubeadm-dind-cluster:v1.9
 
 function dind::find-free-ipv4-subnet() {
-  local allocatedNets curNet
-  allocatedNets="$(
+  local maxIP anAddressInNewSubnet
+
+  subnetSize="$1"
+
+  maxIP=$( dind::ipv4::find-maximum-claimed-ip )
+
+  # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
+  # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
+  # But, consider:
+  # maxIP: 10.0.0.255
+  # maybeNextMinHost: 10.0.1.0
+  # In the above, a subnet size of /16, will start at 10.0.0.0 - which is invalid.
+  # So we need to start the new subnet at least 32-(subnetSize) IP spaces away.
+  anAddressInNewSubnet=$(( maxIP + (1<<(32-subnetSize)) ))
+
+  # apply mask to get min host
+  nextMinHost=$(( anAddressInNewSubnet & $(dind::ipv4::netmask "$subnetSize") ))
+
+  dind::ipv4::itoa "$nextMinHost"
+}
+
+function dind::ipv4::netmask() {
+  local netmask i
+  netmask=0
+  for i in $( seq 32 $(( 32 - $1 )) )
+  do
+    netmask=$(( netmask + 2**i ))
+  done
+  echo "$netmask"
+}
+
+function dind::ipv4::find-maximum-claimed-ip() {
+  local maxIP upperIPs b m i
+  maxIP=0
+  upperIPs="$(
     docker network ls --format '{{ .Name }}' | while read -r nw
     do
-      docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}"
+      subnet="$( docker network inspect "$nw" --format "{{ range .IPAM.Config }}{{ .Subnet }}{{ end }}" )"
+      if [ -z "$subnet" ]
+      then
+        continue
+      fi
+      IFS='/' read -r b m <<<"$subnet"
+      echo $(( $(dind::ipv4::atoi "$b") + (1<<(32-m)) - 1 ))
     done
   )"
 
-  # this is a very naive implementations which ignores any netmask and
-  # basically assumes each net to be /16.
-  for i in $(seq 192 254) $(seq 0 191)
+  for i in $upperIPs
   do
-    curNet="10.${i}.0.0"
-    if ! echo "$allocatedNets" | grep -q "^${curNet}"
+    if [ "$(( i - maxIP ))" -gt 1 ]
     then
-      echo "$curNet"
-      return 0
+      maxIP="$i"
     fi
   done
-  return 1
+
+  echo "$maxIP"
+}
+
+function dind::ipv4::itoa() {
+  echo -n $(($(($(($(($1/256))/256))/256))%256)).
+  echo -n $(($(($(($1/256))/256))%256)).
+  echo -n $(($(($1/256))%256)).
+  echo $(($1%256))
+}
+
+function dind::ipv4::atoi() {
+  local ip="$1"
+  local ret=0
+  for (( i=0 ; i<4 ; ++i ))
+  do
+    (( ret += ${ip%%.*} * ( 256**(3-i) ) ))
+    ip=${ip#*.}
+  done
+  echo $ret
 }
 
 function dind::find-free-local-apiserver-port() {
@@ -212,7 +266,6 @@ fi
 
 DEFAULT_DIND_LABEL='mirantis.kubeadm_dind_cluster_runtime'
 : "${DIND_LABEL:=${DEFAULT_DIND_LABEL}}"
-: "${APISERVER_PORT:=$(dind::find-free-local-apiserver-port)}"
 
 # not configurable for now, would need to setup context for kubectl _inside_ the cluster
 readonly INTERNAL_APISERVER_PORT=8080
@@ -775,7 +828,7 @@ function dind::configure-kubectl {
   context_name="$(dind::context-name)"
   cluster_name="$(dind::context-name)"
   "${kubectl}" config set-cluster "$cluster_name" \
-    --server="http://${host}:${APISERVER_PORT}" \
+    --server="http://${host}:$(dind::apiserver-port)" \
     --insecure-skip-tls-verify=true
   "${kubectl}" config set-context "$context_name" --cluster="$cluster_name"
 }
@@ -854,7 +907,7 @@ function dind::init {
   fi
   local master_name container_id
   master_name="$(dind::master-name)"
-  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
+  container_id=$(dind::run "${master_name}" "$(dind::master-ip)" 1 ${local_host}:$(dind::apiserver-port):${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})
   # FIXME: I tried using custom tokens with 'kubeadm ex token create' but join failed with:
   # 'failed to parse response as JWS object [square/go-jose: compact JWS format must have three parts]'
   # So we just pick the line from 'kubeadm init' output
@@ -1161,7 +1214,7 @@ function dind::wait-for-ready {
   if [[ ${IP_MODE} = "ipv6" ]]; then
       local_host="[::1]"
   fi
-  dind::step "Access dashboard at:" "http://${local_host}:${APISERVER_PORT}/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
+  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 function dind::up {
@@ -1287,18 +1340,20 @@ function dind::restore_container {
 }
 
 function dind::restore {
+  local apiserver_port local_host containter_id pid pids
   dind::down
   dind::step "Restoring master container"
   dind::set-master-opts
+  apiserver_port="$( dind::apiserver-port )"
   for ((n=0; n <= NUM_NODES; n++)); do
     (
       if [[ n -eq 0 ]]; then
         dind::step "Restoring master container"
-        local local_host="127.0.0.1"
+        local_host="127.0.0.1"
         if [[ ${IP_MODE} = "ipv6" ]]; then
           local_host="[::1]"
         fi
-        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${APISERVER_PORT}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
+        dind::restore_container "$(dind::run -r "$(dind::master-name)" "$(dind::master-ip)" 1 ${local_host}:${apiserver_port}:${INTERNAL_APISERVER_PORT} ${master_opts[@]+"${master_opts[@]}"})"
         dind::step "Master container restored"
       else
         dind::step "Restoring node container:" ${n}
@@ -1339,6 +1394,31 @@ function dind::down {
   fi
 }
 
+function dind::apiserver-port {
+  # APISERVER_PORT is explicitely set
+  if [ -n "${APISERVER_PORT:-}" ]
+  then
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # Get the port from the master
+  local master port
+  master="$(dind::master-name)"
+  # 8080/tcp -> 127.0.0.1:8082  =>  8082
+  port="$( docker port "$master" 2>/dev/null | awk -F: "/^${INTERNAL_APISERVER_PORT}/{ print \$NF }" )"
+  if [ -n "$port" ]
+  then
+    APISERVER_PORT="$port"
+    echo "$APISERVER_PORT"
+    return
+  fi
+
+  # get a random free port
+  APISERVER_PORT="$(dind::find-free-local-apiserver-port)"
+  echo "$APISERVER_PORT"
+}
+
 function dind::master-name {
   echo "kube-master$( dind::clusterSuffix )"
 }
@@ -1376,11 +1456,11 @@ function dind::node-ip {
 function dind::get-ip-from-range() {
   local idx="$1"
 
-  read -r range _ <<<"$( dind::get-subnet )"
+  read -r net _ <<<"$( dind::get-subnet )"
+  ipNum="$( dind::ipv4::atoi "$net" )"
+  ipNum=$(( ipNum + idx ))
 
-  printf '%s.%s\n' \
-    "$( echo "$range" | cut -d. -f1-3 )" \
-    "$idx"
+  dind::ipv4::itoa "$ipNum"
 }
 
 function dind::get-subnet {
@@ -1395,8 +1475,8 @@ function dind::get-subnet {
 
   if [ "$netDataErr" -ne 0 ]
   then
-    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet)}"
     mask="${DIND_SUBNET_SIZE:-16}"
+    net="${DIND_SUBNET:-$(dind::find-free-ipv4-subnet "$mask")}"
     exists=0
   else
     IFS=/ read -r net mask <<<"$netData"

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1489,13 +1489,19 @@ function dind::remove-volumes {
 }
 
 function dind::start-port-forwarder {
-  local fwdr
+  set -x
+
+  local fwdr port
   fwdr="${DIND_PORT_FORWARDER:-}"
 
-  [ -n "$fwdr" ] || return 0
-  [ -x "$fwdr" ] || return 0
+  if [ -n "$fwdr" ] && [ -x "$fwdr" ]
+  then
+    port="$( dind::apiserver-port )"
+    dind::step "+ Setting up port-forwarding for :${port}"
+    "$fwdr" "$port"
+  fi
 
-  "$fwdr" "$( dind::apiserver-port )"
+  set +x
 }
 
 function dind::sha1 {

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -83,7 +83,7 @@ function dind::find-free-ipv4-subnet() {
 function dind::ipv4::netmask() {
   local netmask i
   netmask=0
-  for i in $( seq 32 $(( 32 - $1 )) )
+  for i in $( seq $(( 32 - $1 )) 32 )
   do
     netmask=$(( netmask + 2**i ))
   done

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -59,6 +59,12 @@ function dind::find-free-ipv4-subnet() {
 
   maxIP=$( dind::ipv4::find-maximum-claimed-ip )
 
+  if [ $maxIP -eq 0 ]
+  then
+    echo '10.192.0.0'
+    return
+  fi
+
   # maxIP is the highest IP we cannot use (because it already belongs to a subnet)
   # One could argue that maxIP+1 could be the MinHost of the subnet we're about to allocate (a.k.a. "new subnet").
   # But, consider:

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1537,9 +1537,10 @@ function dind::do-run-e2e {
     fi
   fi
   dind::need-source
-  local test_args="--host=http://${host}:${INTERNAL_APISERVER_PORT}"
+  local kubeapi test_args term
   local -a e2e_volume_opts=()
-  local term=
+  kubeapi="http://${host}:$(dind::apiserver-port)"
+  test_args="--host=${kubeapi}"
   if [[ ${focus} ]]; then
     test_args="--ginkgo.focus=${focus} ${test_args}"
   fi
@@ -1562,14 +1563,14 @@ function dind::do-run-e2e {
          --net=host \
          "${build_volume_args[@]}" \
          -e KUBERNETES_PROVIDER=dind \
-         -e KUBE_MASTER_IP=http://${host}:${INTERNAL_APISERVER_PORT} \
+         -e KUBE_MASTER_IP="${kubeapi}" \
          -e KUBE_MASTER=local \
          -e KUBERNETES_CONFORMANCE_TEST=y \
          -e GINKGO_PARALLEL=${parallel} \
          ${e2e_volume_opts[@]+"${e2e_volume_opts[@]}"} \
          -w /go/src/k8s.io/kubernetes \
          "${e2e_base_image}" \
-         bash -c "cluster/kubectl.sh config set-cluster dind --server='http://${host}:${INTERNAL_APISERVER_PORT}' --insecure-skip-tls-verify=true &&
+         bash -c "cluster/kubectl.sh config set-cluster dind --server='${kubeapi}' --insecure-skip-tls-verify=true &&
          cluster/kubectl.sh config set-context dind --cluster=dind &&
          cluster/kubectl.sh config use-context dind &&
          go run hack/e2e.go -- --v 6 --test --check-version-skew=false --test_args='${test_args}'"

--- a/test.sh
+++ b/test.sh
@@ -35,6 +35,7 @@ K8S_PR="${K8S_PR:-}"
 
 tempdir="$(mktemp -d)"
 export KUBECTL_DIR="${tempdir}"
+export KUBECONFIG="${KUBECTL_DIR}/kube.conf"
 
 function cleanup {
   if [[ ${TRAVIS:-} && $? -ne 0 ]]; then
@@ -59,9 +60,7 @@ fi
 
 function test-cluster {
   local kubectl="${KUBECTL_DIR}/kubectl"
-  # context name for the default cluster
-  #   (hashed 'mirantis.kubeadm_dind_cluster_runtime')
-  local defaultContext='dind-8b6554faeab30c4beae1f439af392901406ba5a2'
+  local defaultContext='dind'
 
   if [[ ${BUILD_HYPERKUBE:-} ]]; then
     kubectl="${PWD}/cluster/kubectl.sh"

--- a/test.sh
+++ b/test.sh
@@ -59,7 +59,10 @@ fi
 
 function test-cluster {
   local kubectl="${KUBECTL_DIR}/kubectl"
-  local defaultServer='localhost:8080'
+  # context name for the default cluster
+  #   (hashed 'mirantis.kubeadm_dind_cluster_runtime')
+  local defaultContext='dind-8b6554faeab30c4beae1f439af392901406ba5a2'
+
   if [[ ${BUILD_HYPERKUBE:-} ]]; then
     kubectl="${PWD}/cluster/kubectl.sh"
   fi
@@ -71,9 +74,9 @@ function test-cluster {
   fi
   bash -x "${DIND_ROOT}"/dind-cluster.sh clean
   time bash -x "${DIND_ROOT}"/dind-cluster.sh up
-  "${kubectl}" --server="$defaultServer" get pods -n kube-system | grep kube-dns
+  "${kubectl}" --context="$defaultContext" get pods -n kube-system | grep kube-dns
   time bash -x "${DIND_ROOT}"/dind-cluster.sh up
-  "${kubectl}" --server="$defaultServer" get pods -n kube-system | grep kube-dns
+  "${kubectl}" --context="$defaultContext" get pods -n kube-system | grep kube-dns
   bash -x "${DIND_ROOT}"/dind-cluster.sh down
   bash -x "${DIND_ROOT}"/dind-cluster.sh clean
 }


### PR DESCRIPTION
This eases the usage of multiple parallel clusters. Users now do not need to specify the network and local apiserver port manually -- it will be automatically found.

### Some important details

#### APIServer port is completely random

We leave it to docker to decide which port should be used for the port forwarding. This means that there is no default anymore (previous to this PR the default was `8080`), so also "default" clusters (without `DIND_LABEL` set) will use a random port.

#### Subnet for docker network is random

The subnet for the cluster will be randomly chosen. Previous to this PR the default subnet was `10.192.0.0`. Now, we ask docker on which networks are already allocated and try to use a subnet right after the "highest" allocated IP. Only if docker has no subnets allocated yet, we use `10.192.0.0`.
The whole automatism also works when different subnet sizes are in play.

One caveat: This mechanism is racy. Something else might claim a subnet between the time where we query docker for its networks and we actually create the network.

#### Port forwarder started by `dind-cluster.sh`

As the APIServer port it now completely random, it is hard to set up the port forwarding (in case of a remote docker host) up front. So we added a new config option to `dind-cluster`: `DIND_PORT_FORWARDER`
- Users can set this variable to a path to a executable
- When we now the random APIServer port, we call out to that executable
- We pass the random port as the first argument to the executable
- When `DIND_PORT_FORWARDER` is not set / empty we ignore it and don't do any external call

#### Configuration options as before

The variables `DIND_SUBNET`, `DIND_SUBNET_SIZE` & `APISERVER_PORT` will still be used if set.

#### New subcommand `apiserver-port`

Calling `./dind-cluster.sh apiserver-port` can be used to query which port the APIServer of a cluster is listening on. 