### PR TITLE
Add CI for kube-router networking option

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -503,6 +503,14 @@ jobs:
       CNI_PLUGIN: weave
     <<: *test
 
+  test_1.10_kube_router:
+    <<: *defaults
+    environment:
+      <<: *env
+      DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.10
+      CNI_PLUGIN: kube-router
+    <<: *test
+
   test_1.11:
     <<: *defaults
     environment:
@@ -540,6 +548,14 @@ jobs:
       <<: *env
       DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.11
       CNI_PLUGIN: weave
+    <<: *test
+
+  test_1.11_kube_router:
+    <<: *defaults
+    environment:
+      <<: *env
+      DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.11
+      CNI_PLUGIN: kube-router
     <<: *test
 
   test_src_release:
@@ -673,6 +689,9 @@ workflows:
     - test_1.10_weave:
         requires:
         - build
+    - test_1.10_kube_router:
+        requires:
+        - build
     - test_1.11:
         requires:
         - build
@@ -686,6 +705,9 @@ workflows:
         requires:
         - build
     - test_1.11_weave:
+        requires:
+        - build
+    - test_1.11_kube_router:
         requires:
         - build
     - test_src_release:
@@ -716,8 +738,10 @@ workflows:
         - test_1.10_calico
         - test_1.10_calico_kdd
         - test_1.10_weave
+        - test_1.10_kube_router
         - test_1.11
         - test_1.11_flannel
         - test_1.11_calico
         - test_1.11_calico_kdd
         - test_1.11_weave
+        - test_1.11_kube_router

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The first `dind/dind-cluster.sh up` invocation can be slow because it
 needs to build the base image and Kubernetes binaries. Subsequent
 invocations are much faster.
 
-## IPv6 Mode (experimental)
+## IPv6 Mode
 To run Kubernetes in IPv6 only mode, set the environment variable IP_MODE
 to "ipv6". There are additional customizations that you can make for IPv6,
 to set the prefix used for DNS64, subnet prefix to use for DinD, and
@@ -135,34 +135,14 @@ export DIND_SUBNET=fd00:77::
 export SERVICE_CIDR=fd00:77:30::/110
 ```
 
-As of November 28th, there are two IPv6 Kuberentes PRs in-flight. One is for
-Kubenet and one for E2E tests (neither is required for IPv6 use). You can
-cherry pick these PRs, if desired, and then set the BUILD_HYPERKUBE and
-BUILD_KUBEADM flags, to include the changes in a local Kubernetes repo.
-
-```
-PR #56245 Updates kubenet CNI template for v0.3.1"
-PR #52748 "Add brackets around IPv6 addrs in e2e test IP:port endpoints"
-
-git fetch origin pull/56245/head:pr56245
-git log --abbrev-commit pr56245 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
-
-git fetch origin pull/52748/head:pr52748
-git log --abbrev-commit pr52748 --oneline --abbrev-commit -n 1 | cut -f 1 -d" "
-```
-
-Note: If you run into a kube-proxy crash during an attempt to modify conntrack
-settings, you'll need to patch that is mentioned in this issue:
-
-```
-https://github.com/kubernetes-sigs/kubeadm-dind-cluster/issues/50
-```
+NOTE: If you use `kube-router` for networking, IPv6 is not supported, as of
+July 2018.
 
 ## Configuration
 You may edit `config.sh` to override default settings. See comments in
 [the file](config.sh) for more info. In particular, you can specify
 CNI plugin to use via `CNI_PLUGIN` variable (`bridge`, `flannel`,
-`calico`, `weave`).
+`calico`, `weave`, `kube-router`).
 
 ## Remote Docker / GCE
 It's possible to build Kubernetes on a remote machine running Docker.


### PR DESCRIPTION
Updates CircleCI to test with CNI_PLUGIN set to kube-router. Also
updated the README.md for kube-router and IPv6 in general.

Not sure if this should only be for K8s v1.11 or if it should be on
v1.10 as well (I added that for now).

Fixes Issue: #168 
