### PR TITLE
Add a env variable to allow for setting of the storage mapping

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -300,6 +300,7 @@ SKIP_SNAPSHOT="${SKIP_SNAPSHOT:-}"
 E2E_REPORT_DIR="${E2E_REPORT_DIR:-}"
 DIND_NO_PARALLEL_E2E="${DIND_NO_PARALLEL_E2E:-}"
 DNS_SERVICE="${DNS_SERVICE:-kube-dns}"
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
 
 DIND_CA_CERT_URL="${DIND_CA_CERT_URL:-}"
 DIND_PROPAGATE_HTTP_PROXY="${DIND_PROPAGATE_HTTP_PROXY:-}"
@@ -746,6 +747,7 @@ function dind::run {
   local -a opts=("${ip_arg}" "${ip}" "$@")
   local -a args=("systemd.setenv=CNI_PLUGIN=${CNI_PLUGIN}")
   args+=("systemd.setenv=IP_MODE=${IP_MODE}")
+  args+=("systemd.setenv=DIND_STORAGE_DRIVER=${DIND_STORAGE_DRIVER}")
   if [[ ${IP_MODE} = "ipv6" ]]; then
       opts+=(--sysctl net.ipv6.conf.all.disable_ipv6=0)
       opts+=(--sysctl net.ipv6.conf.all.forwarding=1)

--- a/image/rundocker
+++ b/image/rundocker
@@ -34,6 +34,8 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DIND_STORAGE_DRIVER="${DIND_STORAGE_DRIVER:-overlay2}"
+
 # Ensure shared mount propagation to ensure volume mounting works for Kubernetes.
 # Took it from here:
 # https://github.com/marun/dkr-systemd-dind/blob/25702cf7a4a73bcc355a492f4e5ca96cc562a5a5/dind-setup.sh#L46
@@ -63,9 +65,14 @@ echo "Trying to load overlay module (this may fail)" >&2
 modprobe overlay || true
 
 storage_opts=
-if grep -q '[[:blank:]]overlay[[:blank:]]*' /proc/filesystems; then
-    # --storage-opt overlay2.override_kernel_check=true is needed for CentOS systems
-    storage_opts="--storage-driver=overlay2 --storage-opt overlay2.override_kernel_check=true"
+if [ "$DIND_STORAGE_DRIVER" == "overlay2" ]; then
+    DIND_STORAGE_OPTS="--storage-driver=${DIND_STORAGE_DRIVER} --storage-opt overlay2.override_kernel_check=true"
+    if grep -q '[[:blank:]]overlay[[:blank:]]*' /proc/filesystems; then
+        # --storage-opt overlay2.override_kernel_check=true is needed for CentOS systems
+        storage_opts="${DIND_STORAGE_OPTS}"
+    fi
+else
+    storage_opts="--storage-driver=${DIND_STORAGE_DRIVER}"
 fi
 
 # FIXME: this fix really concerns kubelet, so perhaps it should go


### PR DESCRIPTION
This change will add a knob to allow for disabling of overlay2 storage mapping,
and instead use a user selected docker storage mapping.