### PR TITLE
After the string split is complete, IFS should be restored

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -163,6 +163,7 @@ function dind::net-name {
 function dind::extract-ipv4-subnet() {
   # If only one subnet, there may be a leading space in list of subnets
   local trimmed="$( echo "$1" | sed -e 's/^[[:space:]]*//')"
+  local old_ifs=$IFS
   IFS=' ' subnets=( "${trimmed}" )
   for subnet in "${subnets[@]}"; do
     if [[ -z "${subnet}" || "${subnet}" =~ ":" ]]; then
@@ -171,6 +172,8 @@ function dind::extract-ipv4-subnet() {
     IFS='/' parts=( $subnet )
     DIND_SUBNET="${parts[0]}"
     DIND_SUBNET_SIZE="${parts[1]}"
+    # recover old IFS
+    IFS=$old_ifs
     return
   done
   echo "ERROR: Unable to extract subnet for $( dind::net-name ) - aborting..."


### PR DESCRIPTION
After the string split is completed, the IFS should be restored to avoid affecting subsequent operations.