### PR TITLE
Enable ability to use IPVS mode for kube-proxy

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -61,6 +61,8 @@ RUN clean-install apt-utils \
     iptables \
     iproute2 \
     iputils-ping \
+    ipset \
+    ipvsadm \
     jq \
     kmod \
     lsb-core \

--- a/image/hypokube_base.dkr
+++ b/image/hypokube_base.dkr
@@ -18,6 +18,8 @@ FROM debian:jessie
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -y \
     && DEBIAN_FRONTEND=noninteractive apt-get -yy -q install \
     iptables \
+    ipset \
+    ipvsadm \
     conntrack \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && DEBIAN_FRONTEND=noninteractive apt-get autoremove -y \


### PR DESCRIPTION
To be able to run kube-proxy in IPVS mode, the ipset app needs to be
present in the container. This commit adds this missing file, and ipvsadm,
and makes them available on the nodes as well, so that IPVS status can
be observed.

To run kube-proxy in IPVS mode, one needs to add the following to the
kubeadm.conf.tmpl file and rebuild the DinD image (and use it locally):

kubeProxy:
  config:
    mode: "ipvs"

Fixes issue: #207 
