### PR TITLE
Fix kube master hostname check for multicluster hostnames

### DIFF
--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -58,7 +58,7 @@ function dind::proxy-cidr-and-no-conntrack {
 }
 
 is_master=
-if [[ "$(hostname)" = kube-master ]]; then
+if [[ "$(hostname)" == kube-master* ]]; then
   is_master=y
 fi
 


### PR DESCRIPTION
In image/wrapkubeadm, there's a test for whether a node is kubernetes master. The current test looks for a fixed name of "kube-master":
```
is_master=
if [[ "$(hostname)" = kube-master ]]; then
  is_master=y
fi
```
But the hostname for a kube master in a multicluster config wont match the expected kube-master:
```
root@kube-master-cluster-20:/usr/local/bin# echo $(hostname)
kube-master-cluster-20
root@kube-master-cluster-20:/usr/local/bin#
```
This check for master should be:
```
is_master=
if [[ "$(hostname)" == kube-master* ]]; then
  is_master=y
fi
```
Where this is used:
```
  if [[ ${is_master} ]]; then
    dind::frob-cluster
  fi
```

Fixes Issue #218