### PR TITLE
IPv6: Adjust subnet prefix used for NAT64.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -441,6 +441,11 @@ jobs:
     environment:
       <<: *env
       IP_MODE: ipv6
+      # Ensure no collisions for NAT64 V4 mapping subnet prefix. First cluster will use 10.100,
+      # second will use 10.120 (cluster ID 20), and third will use random value from 10.101 to
+      # 10.113 (using legacy DIND_LABEL w/o cluster ID, causes random offet from 1..13 to be
+      # added to base prefix.
+      NAT64_V4_SUBNET_PREFIX: "10.100"
       DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.11
     <<: *test_multiple_clusters
 


### PR DESCRIPTION
This commit does several things related to the NAT64 prefix, as specified
by the NAT64_V4_SUBNET_PREFIX environment variable. This prefix is for a
/16 subnet.

First, we want the prefix to be within one of the two private network
ranges (172.16.0.0/12 or 10.0.0.0/8).

Second, to accommodate that, the NAT64_V4_SUBNET_PREFIX will be two octets,
instead of one. The default, if not specified, will be 172.18, to avoid
docker usage of that private network.

Third, the code will range check the prefix, to ensure that it is within
range, based on the private network selected. 172.16 to 172.31 or 10.0 to
10.253 values are allowed.

Fourth, the cluster ID is added to the prefix, so that a unique subnet is
used for each cluster. This affects the allowable values for the prefix.

For 172.16.0.0/12, the prefix plus cluster ID must be from 172.16 to
172.31. For 10.0.0.0/8, the prefix plus cluster ID must be from 10.0 to
10.253. So, for example, if the default 172.18 is used, then cluster IDs
can be from 0 to 13.

Another side effect of this change is w.r.t. legacy mode, where the user
specifies (only) the DIND_LABEL. In that case, a cluster ID is generated,
and we now will use numbers from 1..13 to help keep the values within the
range for the V4 mapping prefix (using 13 instead of 15 as the default
prefix is 172.18).

If the user wants to use the legacy DIND_LABEL, but have a larger range
for cluster IDs, they can set the NAT64_V4_SUBNET_PREFIX to the 10.0.0.0/8
subnet and/or explicitly set the CLUSTER_ID.

Fixes Issue: #220