### PR TITLE
Allow dind-cluster[-v1.11].sh to run on the latest Docker for Mac

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -17,8 +17,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DARWINMODE=False
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+  DARWINMODE=True
 else
   readlinkf(){ readlink -f "$1"; }
 fi
@@ -1020,7 +1022,16 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
+    if [ "${DARWIN_MODE}" == "True" ] ; then
+      # /boot and /lib/modules do not exist with Docker for Mac, but
+      # /tmp is available for bind mounting.
+      BOOTVOL=/tmp
+      LIBMODULESVOL=/tmp
+    else
+      BOOTVOL=/boot
+      LIBMODULESVOL=/lib/modules
+    fi
+    opts+=(-v ${BOOTVOL}:/boot -v ${LIBMODULESVOL}:/lib/modules)
   fi
 
   if [[ ${ENABLE_CEPH} ]]; then

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -17,8 +17,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DARWINMODE=False
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+  DARWINMODE=True
 else
   readlinkf(){ readlink -f "$1"; }
 fi
@@ -1020,7 +1022,16 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
+    if [ "${DARWIN_MODE}" == "True" ] ; then
+      # /boot and /lib/modules do not exist with Docker for Mac, but
+      # /tmp is available for bind mounting.
+      BOOTVOL=/tmp
+      LIBMODULESVOL=/tmp
+    else
+      BOOTVOL=/boot
+      LIBMODULESVOL=/lib/modules
+    fi
+    opts+=(-v ${BOOTVOL}:/boot -v ${LIBMODULESVOL}:/lib/modules)
   fi
 
   if [[ ${ENABLE_CEPH} ]]; then

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -17,8 +17,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DARWINMODE=False
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+  DARWINMODE=True
 else
   readlinkf(){ readlink -f "$1"; }
 fi
@@ -1020,7 +1022,16 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
+    if [ "${DARWIN_MODE}" == "True" ] ; then
+      # /boot and /lib/modules do not exist with Docker for Mac, but
+      # /tmp is available for bind mounting.
+      BOOTVOL=/tmp
+      LIBMODULESVOL=/tmp
+    else
+      BOOTVOL=/boot
+      LIBMODULESVOL=/lib/modules
+    fi
+    opts+=(-v ${BOOTVOL}:/boot -v ${LIBMODULESVOL}:/lib/modules)
   fi
 
   if [[ ${ENABLE_CEPH} ]]; then

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1023,7 +1023,7 @@ function dind::run {
 
   if [[ ! ${using_linuxkit} ]]; then
     if [ "${DARWIN_MODE}" == "True" ] ; then
-      # /boot and /lib/modules do not exist with Docker for Mac,
+      # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp
       LIBMODULESVOL=/tmp

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/fixed/dind-cluster-v1.8.sh
+++ b/fixed/dind-cluster-v1.8.sh
@@ -17,8 +17,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DARWINMODE=False
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+  DARWINMODE=True
 else
   readlinkf(){ readlink -f "$1"; }
 fi
@@ -1020,7 +1022,16 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
+    if [ "${DARWIN_MODE}" == "True" ] ; then
+      # /boot and /lib/modules do not exist with Docker for Mac, but
+      # /tmp is available for bind mounting.
+      BOOTVOL=/tmp
+      LIBMODULESVOL=/tmp
+    else
+      BOOTVOL=/boot
+      LIBMODULESVOL=/lib/modules
+    fi
+    opts+=(-v ${BOOTVOL}:/boot -v ${LIBMODULESVOL}:/lib/modules)
   fi
 
   if [[ ${ENABLE_CEPH} ]]; then

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1022,7 +1022,7 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    if [ "${DARWIN_MODE}" == "True" ] ; then
+    if [ "${DARWINMODE}" == "True" ] ; then
       # /boot and /lib/modules do not exist with Docker for Mac, but
       # /tmp is available for bind mounting.
       BOOTVOL=/tmp

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -17,8 +17,10 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
+DARWINMODE=False
 if [ $(uname) = Darwin ]; then
   readlinkf(){ perl -MCwd -e 'print Cwd::abs_path shift' "$1";}
+  DARWINMODE=True
 else
   readlinkf(){ readlink -f "$1"; }
 fi
@@ -1020,7 +1022,16 @@ function dind::run {
   dind::step "Starting DIND container:" "${container_name}"
 
   if [[ ! ${using_linuxkit} ]]; then
-    opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
+    if [ "${DARWIN_MODE}" == "True" ] ; then
+      # /boot and /lib/modules do not exist with Docker for Mac, but
+      # /tmp is available for bind mounting.
+      BOOTVOL=/tmp
+      LIBMODULESVOL=/tmp
+    else
+      BOOTVOL=/boot
+      LIBMODULESVOL=/lib/modules
+    fi
+    opts+=(-v ${BOOTVOL}:/boot -v ${LIBMODULESVOL}:/lib/modules)
   fi
 
   if [[ ${ENABLE_CEPH} ]]; then


### PR DESCRIPTION
The latest versions of Docker for Mac have changed what directories by default are
setup for bind volume mounts. The dind-cluster*.sh scripts assume that /boot and
/lib/modules can be bind mounted, but this is not the case with the new Docker for
Mac versions.

This commit detects if the script is running on a Mac, and if so, it replaces /boot
and /lib/modules with /tmp, which is by default bind mountable on the latest Docker
for Mac.

Tested on Docker for Mac version 2.0.0.0-beta1-mac75 (build 27117) with Kubernetes
version 1.11.0.

Signed-off-by: Kyle Mestery <mestery@mestery.com>