### PR TITLE
Pin kube-router to fixed version

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,12 @@ required for pods to communicate across nodes.
 
 To use kube-router, set the CNI_PLUGIN environment variable to "kube-router".
 
+NOTE: Currently pinning kube-router to v0.2.0, because of issue seen with
+cleanup, when using newer (latest) kube-router.
+
+NOTE: This has only been tested with Kubernetes 1.11, and currently fails,
+when using Kuberentes 1.12 (alpha).
+
 ## IPv6 Mode
 To run Kubernetes in IPv6 only mode, set the environment variable IP_MODE
 to "ipv6". There are additional customizations that you can make for IPv6,


### PR DESCRIPTION
We are seeing failures in CI, when enabling kube-router as the CNI plugin.
The script used to apply this plugin uses the latest kube-router image,
which latest changes are causing failure in the down/clean step.

To avert this problem, this commit pins the CNI plugin to v0.2.0, which
is a known working version with k-d-c.  The general script is included
in dind-cluster.sh, with the version specified and that is used to install
kube-router.

Also, during the cleanup invocation, this same version is called out.

This allows us to control this dependency, and newer kube-router versions
can be tested, before updating k-d-c with a newer version.

The commit will help resolve CI failures seen recently.

NTOE: There is a warning, when bringing down the cluster, where kube-router
indicates that it cannot delete pod egress iptable rule (saying set
kube-router-pod-subnets does not exist). Seems to be benign, as subsequent
up operation works.

NOTE: This was tested with K8s 1.11. When I tried 1.12, I had errors
bringing up the cluster. The kube-router ds was not starting up, and there
was an error message about module ip_vs. This will need further investigation,
before kube-router can be used with newer versions (in v4 mode). For now,
we just want to resolve CI breeakage.

Fixes Issue: #239