### PR TITLE
Add option to allow using pre-built Kubernetes binaries

### DIFF
--- a/config.sh
+++ b/config.sh
@@ -27,6 +27,13 @@ DIND_IMAGE="${DIND_IMAGE:-mirantis/kubeadm-dind-cluster:v1.10}"
 # Set to non-empty string to enable building hyperkube
 # BUILD_HYPERKUBE=y
 
+# Use pre-built Kubernetes binaries (hyperkube and kubeadm) on the
+# host, located in the specified directory. When this environment
+# variable is set, BUILD_KUBEADM and BUILD_HYPERKUBE will be ignored.
+# This will not work with a remote docker engine (e.g. started via
+# docker-machine on GCE) unless the file is placed on the target machine.
+DIND_K8S_BIN_DIR="${DIND_K8S_BIN_DIR:-}"
+
 # download kubectl on the host
 # Set automatically based on DIND image version tag
 # if image version tag is of the form vNNN.NNN

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi

--- a/fixed/config-stable.sh
+++ b/fixed/config-stable.sh
@@ -26,6 +26,13 @@ DIND_IMAGE="${DIND_IMAGE:-mirantis/kubeadm-dind-cluster:stable}"
 # Set to non-empty string to enable building hyperkube
 # BUILD_HYPERKUBE=y
 
+# Use pre-built Kubernetes binaries (hyperkube and kubeadm) on the
+# host, located in the specified directory. When this environment
+# variable is set, BUILD_KUBEADM and BUILD_HYPERKUBE will be ignored.
+# This will not work with a remote docker engine (e.g. started via
+# docker-machine on GCE) unless the file is placed on the target machine.
+DIND_K8S_BIN_DIR="${DIND_K8S_BIN_DIR:-}"
+
 # download kubectl on the host
 # Set automatically based on DIND image version tag
 # if image version tag is of the form vNNN.NNN

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -486,6 +486,10 @@ done
 DIND_IMAGE="${DIND_IMAGE:-}"
 BUILD_KUBEADM="${BUILD_KUBEADM:-}"
 BUILD_HYPERKUBE="${BUILD_HYPERKUBE:-}"
+if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
+  BUILD_KUBEADM=""
+  BUILD_HYPERKUBE=""
+fi
 KUBEADM_SOURCE="${KUBEADM_SOURCE-}"
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE-}"
 NUM_NODES=${NUM_NODES:-2}
@@ -1019,6 +1023,9 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
+  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+      opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
+  fi
   if [[ ! ${using_linuxkit} ]]; then
     opts+=(-v /boot:/boot -v /lib/modules:/lib/modules)
   fi


### PR DESCRIPTION
This change adds a "DIND_K8S_BIN_DIR" environment variable to allow the dind-cluster.sh
script to use pre-built binaries on the host for hyperkube and kubeadm to be used in
node containers.

For example, if the 'hyperkube' and 'kubeadm' binaries are in the directory
/home/myname/k8s_bin_dir on the host, then a user would set the environment
variable:

    export DIND_K8S_BIN_DIR=/home/myname/k8s_bin_dir

and then run 'dind-cluster.sh up' in the normal fashion.

With the proposed change, dind-cluster.sh would create a bind mount from
the '/k8s' directory on each node container to the Kubernetes binary directory
on the host, and there would be no build of Kubernetes binaries.

Note that the setting of DIND_K8S_BIN_DIR to a non-null string will cause
the BUILD_HYPERKUBE and BUILD_KUBEADM environment variables to be
ignored.

This change is required for Kubernetes IPv6 CI periodic tests, since all that is available
for these periodic tests are the binary builds based on Kubernetes latest master
(i.e. no source is available).