### PR TITLE
Add support for containerd

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -588,6 +588,14 @@ jobs:
       DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.11
     <<: *test
 
+  test_1.11_containerd:
+    <<: *defaults
+    environment:
+      <<: *env
+      DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.11
+      DIND_CRI: 'containerd'
+    <<: *test
+
   test_1.11_flannel:
     <<: *defaults
     environment:
@@ -647,6 +655,14 @@ jobs:
     environment:
       <<: *env
       DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.12
+    <<: *test
+
+  test_1.12_containerd:
+    <<: *defaults
+    environment:
+      <<: *env
+      DIND_IMAGE: mirantis/kubeadm-dind-cluster:v1.12
+      DIND_CRI: 'containerd'
     <<: *test
 
   test_1.12_flannel:
@@ -886,6 +902,9 @@ workflows:
     - test_1.11:
         requires:
         - build
+    - test_1.11_containerd:
+        requires:
+        - build
     # - test_1.11_flannel:
     #     requires:
     #     - build
@@ -917,6 +936,9 @@ workflows:
         requires:
         - build
     - test_1.12:
+        requires:
+        - build
+    - test_1.12_containerd:
         requires:
         - build
     - test_1.12_flannel:
@@ -978,6 +1000,7 @@ workflows:
         # - test_1.10_kube_router
         # - test_1.10_ptp
         - test_1.11
+        - test_1.11_containerd
         # - test_1.11_flannel
         # - test_1.11_calico
         # - test_1.11_calico_kdd
@@ -986,6 +1009,7 @@ workflows:
         # - test_1.11_ptp
         # - test_1.11_ipv4_only
         - test_1.12
+        - test_1.12_containerd
         - test_1.12_flannel
         # calico is the same for 1.12 as for 1.11
         # - test_1.12_calico

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -38,6 +38,8 @@ STOPSIGNAL SIGRTMIN+3
 LABEL mirantis.kubeadm_dind_cluster=1
 
 ENV ARCH amd64
+ENV CRICTL_VERSION=v1.12.0
+ENV CRICTL_SHA256=e7d913bcce40bf54e37ab1d4b75013c823d0551e6bc088b217bc1893207b4844
 ENV CNI_VERSION=v0.7.1
 ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-"${CNI_VERSION}".tgz
 ENV CNI_SHA1=fb29e20401d3e9598a1d8e8d7992970a36de5e05
@@ -85,7 +87,13 @@ RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add - && a
     "deb [arch=amd64] https://download.docker.com/linux/debian \
     $(lsb_release -cs) \
     stable"
-RUN clean-install docker-ce=17.03.2~ce-0~debian-stretch
+RUN clean-install docker-ce=5:18.09.0~3-0~debian-stretch && \
+    sed -i '/^disabled_plugins/d' /etc/containerd/config.toml
+
+RUN curl -sSL --retry 5 https://github.com/kubernetes-sigs/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz >/tmp/crictl.tar.gz && \
+    echo "${CRICTL_SHA256}  /tmp/crictl.tar.gz" | sha256sum -c && \
+    tar -C /usr/local/bin -xvzf /tmp/crictl.tar.gz && \
+    rm -f /tmp/crictl.tar.gz
 
 RUN mkdir -p /hypokube /etc/systemd/system/docker.service.d /var/lib/kubelet
 

--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -133,6 +133,7 @@ RUN chmod +x /usr/local/bin/rundocker /usr/local/bin/dindnet /usr/local/bin/snap
       rm -f "/tmp/${CNI_ARCHIVE}" && \
     mkdir -p /etc/systemd/system/docker.service.wants && \
     ln -s /lib/systemd/system/dindnet.service /etc/systemd/system/docker.service.wants/ && \
+    ln -s /dind/containerd /var/lib/containerd && \
     ln -s /k8s/hyperkube /usr/bin/kubectl && \
     ln -s /k8s/hyperkube /usr/bin/kubelet && \
     ln -s /k8s/kubeadm /usr/bin/kubeadm

--- a/image/docker.service
+++ b/image/docker.service
@@ -1,35 +1,46 @@
 [Unit]
 Description=Docker Application Container Engine
 Documentation=https://docs.docker.com
-After=network-online.target docker.socket firewalld.service
+BindsTo=containerd.service
+After=network-online.target firewalld.service
 Wants=network-online.target
-Requires=docker.socket
 
 [Service]
-Environment=container=docker
 Type=notify
 # the default is not to use systemd for cgroups because the delegate issues still
 # exists and systemd currently does not support the cgroup feature set required
 # for containers run by docker
 ExecStart=/usr/local/bin/rundocker
 ExecReload=/bin/kill -s HUP $MAINPID
-LimitNOFILE=1048576
+TimeoutSec=0
+RestartSec=2
+Restart=always
+
+# Note that StartLimit* options were moved from "Service" to "Unit" in systemd 229.
+# Both the old, and new location are accepted by systemd 229 and up, so using the old location
+# to make them work for either version of systemd.
+StartLimitBurst=3
+
+# Note that StartLimitInterval was renamed to StartLimitIntervalSec in systemd 230.
+# Both the old, and new name are accepted by systemd 230 and up, so using the old name to make
+# this option work for either version of systemd.
+StartLimitInterval=60s
+
 # Having non-zero Limit*s causes performance problems due to accounting overhead
 # in the kernel. We recommend using cgroups to do container-local accounting.
+LimitNOFILE=infinity
 LimitNPROC=infinity
 LimitCORE=infinity
-# Uncomment TasksMax if your systemd version supports it.
-# Only systemd 226 and above support this version.
-#TasksMax=infinity
-TimeoutStartSec=0
+
+# Comment TasksMax if your systemd version does not supports it.
+# Only systemd 226 and above support this option.
+TasksMax=infinity
+
 # set delegate yes so that systemd does not reset the cgroups of docker containers
 Delegate=yes
+
 # kill only the docker process, not all processes in the cgroup
 KillMode=process
-# restart the docker process if it exits prematurely
-Restart=on-failure
-StartLimitBurst=3
-StartLimitInterval=60s
 
 [Install]
 WantedBy=multi-user.target

--- a/image/kubeadm.conf.1.10.tmpl
+++ b/image/kubeadm.conf.1.10.tmpl
@@ -25,3 +25,4 @@ schedulerExtraArgs:
   {{COMPONENT_FEATURE_GATES}}
 {{SCHEDULER_EXTRA_ARGS}}
 unifiedControlPlaneImage: mirantis/hypokube:final
+criSocket: "{{CRI_SOCKET}}"

--- a/image/kubeadm.conf.1.11.tmpl
+++ b/image/kubeadm.conf.1.11.tmpl
@@ -147,6 +147,7 @@ networking:
   serviceSubnet: "{{SVC_SUBNET}}"
 nodeRegistration:
   name: {{KUBE_MASTER_NAME}}
+  criSocket: "{{CRI_SOCKET}}"
 schedulerExtraArgs:
   {{COMPONENT_FEATURE_GATES}}
 {{SCHEDULER_EXTRA_ARGS}}

--- a/image/kubeadm.conf.1.12.tmpl
+++ b/image/kubeadm.conf.1.12.tmpl
@@ -8,7 +8,7 @@ apiEndpoint:
 apiVersion: kubeadm.k8s.io/v1alpha3
 kind: InitConfiguration
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: "{{CRI_SOCKET}}"
   name: {{KUBE_MASTER_NAME}}
   taints:
   - effect: NoSchedule

--- a/image/kubeadm.conf.1.13.tmpl
+++ b/image/kubeadm.conf.1.13.tmpl
@@ -16,7 +16,7 @@ bootstrapTokens:
   - authentication
 kind: InitConfiguration
 nodeRegistration:
-  criSocket: /var/run/dockershim.sock
+  criSocket: "{{CRI_SOCKET}}"
   name: {{KUBE_MASTER_NAME}}
   taints:
   - effect: NoSchedule

--- a/image/kubelet.service
+++ b/image/kubelet.service
@@ -10,8 +10,12 @@ Environment="KUBELET_DNS_ARGS=--cluster-dns=10.96.0.10 --cluster-domain=cluster.
 Environment="KUBELET_EVICTION_ARGS=--eviction-hard='memory.available<100Mi,nodefs.available<100Mi,nodefs.inodesFree<1000'"
 Environment="KUBELET_DIND_ARGS="
 Environment="KUBELET_LOG_ARGS=--v=4"
+# FIXME: this breaks k8s 1.10
+# Environment="KUBELET_CONFIG_ARGS=--config=/var/lib/kubelet/config.yaml"
+EnvironmentFile=-/var/lib/kubelet/kubeadm-flags.env
+EnvironmentFile=-/etc/default/kubelet
 ExecStart=
-ExecStart=/k8s/hyperkube kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_FEATURE_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EVICTION_ARGS $KUBELET_DIND_ARGS $KUBELET_LOG_ARGS $KUBELET_EXTRA_ARGS
+ExecStart=/k8s/hyperkube kubelet $KUBELET_KUBECONFIG_ARGS $KUBELET_CONFIG_ARGS $KUBELET_KUBEADM_ARGS $KUBELET_FEATURE_ARGS $KUBELET_SYSTEM_PODS_ARGS $KUBELET_NETWORK_ARGS $KUBELET_DNS_ARGS $KUBELET_EVICTION_ARGS $KUBELET_DIND_ARGS $KUBELET_LOG_ARGS $KUBELET_EXTRA_ARGS
 Restart=always
 StartLimitInterval=0
 RestartSec=10

--- a/image/rundocker
+++ b/image/rundocker
@@ -91,4 +91,8 @@ grep "/var/lib/kubelet/pods[[:space:]]" /proc/mounts  || mount --bind /dind/pods
 mkdir -p /dind/logs /var/log/pods
 grep "/var/log/pods[[:space:]]" /proc/mounts || mount --bind /dind/logs /var/log/pods
 
+if [[ ${DIND_CRI} = containerd ]]; then
+  extra_opts+=("--cri-containerd")
+fi
+
 exec /usr/bin/dockerd -H unix:// "${extra_opts[@]}" --data-root /dind/docker "$@"

--- a/image/rundocker
+++ b/image/rundocker
@@ -64,15 +64,13 @@ fi
 echo "Trying to load overlay module (this may fail)" >&2
 modprobe overlay || true
 
-storage_opts=
-if [ "$DIND_STORAGE_DRIVER" == "overlay2" ]; then
-    DIND_STORAGE_OPTS="--storage-driver=${DIND_STORAGE_DRIVER} --storage-opt overlay2.override_kernel_check=true"
-    if grep -q '[[:blank:]]overlay[[:blank:]]*' /proc/filesystems; then
-        # --storage-opt overlay2.override_kernel_check=true is needed for CentOS systems
-        storage_opts="${DIND_STORAGE_OPTS}"
-    fi
+extra_opts=()
+if [[ ${DIND_STORAGE_DRIVER} == overlay2 ]] && grep -q '[[:blank:]]overlay[[:blank:]]*' /proc/filesystems; then
+  # --storage-opt overlay2.override_kernel_check=true is needed for CentOS systems
+  extra_opts+=(--storage-driver="${DIND_STORAGE_DRIVER}"
+               --storage-opt overlay2.override_kernel_check=true)
 else
-    storage_opts="--storage-driver=${DIND_STORAGE_DRIVER}"
+  extra_opts+=(--storage-driver="${DIND_STORAGE_DRIVER}")
 fi
 
 # FIXME: this fix really concerns kubelet, so perhaps it should go
@@ -80,8 +78,8 @@ fi
 # Kubelet will try to contact GCE metadata server on startup if
 # it detects a GCE VM and this breaks kdc on Travis
 if [[ $(cat /sys/class/dmi/id/product_name) =~ Google ]]; then
-    echo "KDC" >/dmi_product_name
-    mount --bind /dmi_product_name /sys/class/dmi/id/product_name
+  echo "KDC" >/dmi_product_name
+  mount --bind /dmi_product_name /sys/class/dmi/id/product_name
 fi
 
 # Directories bind-mounted from /dind are not managed by the Docker's snapshotting mechanism, e.g. overlayfs.
@@ -93,4 +91,4 @@ grep "/var/lib/kubelet/pods[[:space:]]" /proc/mounts  || mount --bind /dind/pods
 mkdir -p /dind/logs /var/log/pods
 grep "/var/log/pods[[:space:]]" /proc/mounts || mount --bind /dind/logs /var/log/pods
 
-exec /usr/bin/dockerd -H fd:// ${storage_opts} -g /dind/docker "$@"
+exec /usr/bin/dockerd -H unix:// "${extra_opts[@]}" --data-root /dind/docker "$@"

--- a/image/snapshot
+++ b/image/snapshot
@@ -27,8 +27,6 @@ function snapshot::retry {
 }
 
 function snapshot::prepare {
-
-
   if [[ -f /etc/kubernetes/manifests/kube-controller-manager.json || -f /etc/kubernetes/manifests/kube-controller-manager.yaml ]]; then
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
     # FIXME: when using k8s 1.6 kube-dns pods stay in 'Terminating' state
@@ -41,7 +39,7 @@ function snapshot::prepare {
     while kubectl get pods -n kube-system -o name | egrep -q "^pods*/(${DNS_SERVICE}-|kubernetes-dashboard-)"; do
       if ((--n == 0)); then
         echo "WARNING: controller manager glitch: dns & dashboard won't stop; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker
+        systemctl stop kubelet docker containerd
         return
       fi
       sleep 0.3
@@ -96,7 +94,7 @@ function snapshot::save {
     tar -C / -cf /dind/var-run-kubernetes.tar var/run/kubernetes
   fi
 
-  systemctl start kubelet docker
+  systemctl start kubelet docker containerd
 }
 
 function snapshot::restore {
@@ -107,7 +105,7 @@ function snapshot::restore {
   if [[ ${1:-} = "-u" ]]; then
     wrapkubeadm ensure-binaries
   fi
-  start_services docker kubelet
+  start_services docker kubelet containerd
 }
 
 case "${1:-}" in

--- a/image/snapshot
+++ b/image/snapshot
@@ -26,6 +26,22 @@ function snapshot::retry {
   "$@"
 }
 
+function snapshot::clean-containerd {
+  if [[ ${DIND_CRI} != containerd ]]; then
+    return
+  fi
+  crictl="crictl -r unix:///var/run/containerd/containerd.sock"
+  # first, we need to stop the containers
+  ${crictl} ps -q   | xargs -r ${crictl} stop -t 0
+  # then we remove the containers
+  ${crictl} ps -qa  | xargs -r ${crictl} rm
+  # then we stop the pod sandboxes
+  ${crictl} pods -q | xargs -r ${crictl} stopp
+  # and then we remove the pod sandboxes
+  ${crictl} pods -q | xargs -r ${crictl} rmp
+  systemctl stop containerd
+}
+
 function snapshot::prepare {
   if [[ -f /etc/kubernetes/manifests/kube-controller-manager.json || -f /etc/kubernetes/manifests/kube-controller-manager.yaml ]]; then
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
@@ -39,7 +55,8 @@ function snapshot::prepare {
     while kubectl get pods -n kube-system -o name | egrep -q "^pods*/(${DNS_SERVICE}-|kubernetes-dashboard-)"; do
       if ((--n == 0)); then
         echo "WARNING: controller manager glitch: dns & dashboard won't stop; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker containerd
+        systemctl stop kubelet docker
+        snapshot::clean-containerd
         return
       fi
       sleep 0.3
@@ -69,11 +86,13 @@ function snapshot::prepare {
     done
     snapshot::retry kubectl get pods -n kube-system
     systemctl stop kubelet docker
+    snapshot::clean-containerd
     # now it's safe to put back the manifest
     mv /manifests.bak/* /etc/kubernetes/manifests/
     rmdir /manifests.bak
   else
     systemctl stop kubelet docker
+    snapshot::clean-containerd
   fi
 }
 
@@ -81,7 +100,7 @@ function snapshot::save {
   # the scripts expects output the output of 'docker diff' as input
   grep -v '^D ' |
     sed 's@^. /@@' |
-    egrep -v '^(tmp|var/log|etc/mtab|run/)' |
+    egrep -v '^(tmp|var/log|etc/mtab|run/|var/lib/containerd)' |
     while read path; do
       # Here we only add dirs if they're empty, as non-empty dirs will
       # be added automatically by tar
@@ -94,7 +113,7 @@ function snapshot::save {
     tar -C / -cf /dind/var-run-kubernetes.tar var/run/kubernetes
   fi
 
-  systemctl start kubelet docker containerd
+  systemctl start kubelet docker
 }
 
 function snapshot::restore {
@@ -105,7 +124,7 @@ function snapshot::restore {
   if [[ ${1:-} = "-u" ]]; then
     wrapkubeadm ensure-binaries
   fi
-  start_services docker kubelet containerd
+  start_services docker kubelet
 }
 
 case "${1:-}" in

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -18,7 +18,6 @@ set -o nounset
 set -o pipefail
 set -o errtrace
 
-
 HYPERKUBE_SOURCE="${HYPERKUBE_SOURCE:-keep://}"
 KUBEADM_SOURCE="${KUBEADM_SOURCE:-keep://}"
 
@@ -176,6 +175,10 @@ function dind::ensure-binaries-and-hypokube {
     for tag in "${hypokube_extra_tags[@]}"; do
         docker tag "${hypokube_final_image}" "${tag}"
     done
+  fi
+  if [[ ${DIND_CRI} = containerd ]]; then
+    docker image save mirantis/hypokube:final "${hypokube_extra_tags[@]}" |
+      ctr -n k8s.io images import -
   fi
 }
 

--- a/image/wrapkubeadm
+++ b/image/wrapkubeadm
@@ -66,6 +66,9 @@ if [[ -f /dind-sys/sys.tar ]]; then
   tar -C / -xf /dind-sys/sys.tar
 fi
 
+# make data dir for containerd (symlinked to /var/lib/containerd in the Dockerfile)
+mkdir -p /dind/containerd
+
 function dind::retry {
   # based on retry function in hack/jenkins/ scripts in k8s source
   for i in {1..10}; do


### PR DESCRIPTION
This PR adds support for `DIND_CRI=containerd` option which makes k-d-c use containerd as its CRI implementation.