### PR TITLE
Fix containerd on the worker nodes

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1376,7 +1376,9 @@ function dind::join {
   shift
   dind::proxy "${container_id}"
   dind::custom-docker-opts "${container_id}"
-  dind::kubeadm "${container_id}" join --ignore-preflight-errors=all "$@" >/dev/null
+  local -a join_opts=(--ignore-preflight-errors=all
+                      --cri-socket="${CRI_SOCKET}")
+  dind::kubeadm "${container_id}" join "${join_opts[@]}" "$@" >/dev/null
 }
 
 function dind::escape-e2e-name {


### PR DESCRIPTION
We need to pass `--cri-socket` to `kubeadm join` in order
to have worker nodes use containerd.