### PR TITLE
Fix "DIND_K8S_BIN_DIR: unbound variable" error when running fixed scripts

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1037,7 +1037,7 @@ function dind::run {
 
   dind::step "Starting DIND container:" "${container_name}"
 
-  if [[ ${DIND_K8S_BIN_DIR} ]]; then
+  if [[ ! -z ${DIND_K8S_BIN_DIR:-} ]]; then
       opts+=(-v ${DIND_K8S_BIN_DIR}:/k8s)
   fi
   if [[ ! ${using_linuxkit} ]]; then


### PR DESCRIPTION
After https://github.com/kubernetes-sigs/kubeadm-dind-cluster/pull/247 we started to see `DIND_K8S_BIN_DIR: unbound variable` error when running a `fixed` script. This PR is fixing that.