### PR TITLE
Fix custom docker opts

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -2289,7 +2289,7 @@ function dind::custom-docker-opts {
     local json=$(IFS="+"; echo "${jq[*]}")
     docker exec -i ${container_id} /bin/sh -c "mkdir -p /etc/docker && jq -n '${json}' > /etc/docker/daemon.json"
     docker exec ${container_id} systemctl daemon-reload
-    docker exec ${container_id} systemctl restart docker
+    docker exec ${container_id} systemctl restart docker || true
   fi
 }
 


### PR DESCRIPTION
Currently setting custom docker opts seems to be broken. I get:
`Job for docker.service canceled.` and then an exit.

I think this is because we are doing `service docker restart` before we
do:
`Created symlink
/etc/systemd/system/multi-user.target.wants/docker.service →
/lib/systemd/system/docker.service.`

My proposed fix is just to ignore the failed restart. Not really ideal
but I can't work out how to re-order it? Maybe someone more familiar can
suggest a better solution.