### PR TITLE
Allow Calico node image customization

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/fixed/dind-cluster-stable.sh
+++ b/fixed/dind-cluster-stable.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/fixed/dind-cluster-v1.10.sh
+++ b/fixed/dind-cluster-v1.10.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/fixed/dind-cluster-v1.11.sh
+++ b/fixed/dind-cluster-v1.11.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/fixed/dind-cluster-v1.12.sh
+++ b/fixed/dind-cluster-v1.12.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1821,7 +1821,19 @@ function dind::up {
       if [ "${CALICO_VERSION:-v3.3}" != master ]; then
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
-      dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calico.yaml
+      tmpd=$(mktemp -d -t calico.XXXXXX)
+      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      if [ "${CALICO_NODE_IMAGE}" ]; then
+	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
+	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
+	  docker exec $(dind::master-name) docker load -i /calico-node.tar
+	  for ((n=1; n <= NUM_NODES; n++)); do
+	      docker cp ${tmpd}/calico-node.tar $(dind::node-name ${n}):/calico-node.tar
+	      docker exec $(dind::node-name ${n}) docker load -i /calico-node.tar
+	  done
+	  sed -i "s,image: .*calico/node:.*,image: ${CALICO_NODE_IMAGE}," ${tmpd}/calico.yaml
+      fi
+      dind::retry "${kubectl}" --context "$ctx" apply -f ${tmpd}/calico.yaml
       dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/hosted/calicoctl.yaml
       ;;
     calico-kdd)

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1822,7 +1822,7 @@ function dind::up {
 	  dind::retry "${kubectl}" --context "$ctx" apply -f ${manifest_base}/rbac.yaml
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
-      wget ${manifest_base}/hosted/calico.yaml -O ${tmpd}/calico.yaml
+      curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
       if [ "${CALICO_NODE_IMAGE}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar

--- a/fixed/dind-cluster-v1.9.sh
+++ b/fixed/dind-cluster-v1.9.sh
@@ -1823,7 +1823,7 @@ function dind::up {
       fi
       tmpd=$(mktemp -d -t calico.XXXXXX)
       curl -sSLo ${tmpd}/calico.yaml ${manifest_base}/hosted/calico.yaml
-      if [ "${CALICO_NODE_IMAGE}" ]; then
+      if [ "${CALICO_NODE_IMAGE:-}" ]; then
 	  docker save --output ${tmpd}/calico-node.tar ${CALICO_NODE_IMAGE}
 	  docker cp ${tmpd}/calico-node.tar $(dind::master-name):/calico-node.tar
 	  docker exec $(dind::master-name) docker load -i /calico-node.tar


### PR DESCRIPTION
Specifically, this is because I want to use kubeadm-dind-cluster for
testing some of our master code, including a locally built node image.