### PR TITLE
Update apt with apt-utils

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -55,7 +55,8 @@ ENV CONTAINERD_SHA256=9818e3af4f9aac8d55fc3f66114346db1d1acd48d45f88b2cefd3d3baf
 ENV container docker
 
 ARG DEBIAN_FRONTEND=noninteractive
-RUN clean-install apt-utils \
+RUN clean-install apt \
+    apt-utils \
     apt-transport-https \
     bash \
     bridge-utils \


### PR DESCRIPTION
`./build/build-local.sh` fails because it tries to instsall `apt-utils` for a newer version of apt `1.4.9`, which is `1.4.8` in the base image `k8s.gcr.io/debian-base-amd64:0.3`.
apt `1.4.9` was recently released because of [the security issue](https://www.debian.org/security/2019/dsa-4371).

```
$ ./build/build-local.sh
Sending build context to Docker daemon  74.75kB
Step 1/38 : FROM k8s.gcr.io/debian-base-amd64:0.3
 ---> 570ff9f1b6a2
Step 2/38 : STOPSIGNAL SIGRTMIN+3
 ---> Using cache
 ---> 9ecc22556b25
Step 3/38 : LABEL mirantis.kubeadm_dind_cluster=1
 ---> Using cache
 ---> 479f766e959a
Step 4/38 : ENV ARCH amd64
 ---> Using cache
 ---> 142e86cbcbef
Step 5/38 : ENV CRICTL_VERSION=v1.12.0
 ---> Using cache
 ---> 962c7b3915dc
Step 6/38 : ENV CRICTL_SHA256=e7d913bcce40bf54e37ab1d4b75013c823d0551e6bc088b217bc1893207b4844
 ---> Using cache
 ---> 62b86342fa7d
Step 7/38 : ENV CNI_VERSION=v0.7.1
 ---> Using cache
 ---> fb02b465a057
Step 8/38 : ENV CNI_ARCHIVE=cni-plugins-"${ARCH}"-"${CNI_VERSION}".tgz
 ---> Using cache
 ---> cc970753ef76
Step 9/38 : ENV CNI_SHA1=fb29e20401d3e9598a1d8e8d7992970a36de5e05
 ---> Using cache
 ---> a153df13b2dc
Step 10/38 : ENV CONTAINERD_VERSION=1.2.1
 ---> Using cache
 ---> 9436dc7e7fd6
Step 11/38 : ENV CONTAINERD_SHA256=9818e3af4f9aac8d55fc3f66114346db1d1acd48d45f88b2cefd3d3bafb380e0
 ---> Using cache
 ---> 2b20761b276d
Step 12/38 : ENV container docker
 ---> Using cache
 ---> f31f2f440f52
Step 13/38 : ARG DEBIAN_FRONTEND=noninteractive
 ---> Using cache
 ---> ccf75f1cc243
Step 14/38 : RUN clean-install apt-utils     apt-transport-https     bash     bridge-utils     ca-certificates     curl     e2fsprogs     ebtables     ethtool     gnupg2     ipcalc     iptables     iproute2     iputils-ping     ipset     ipvsadm     jq     kmod     lsb-core     less     lzma     liblz4-tool     mount     net-tools     procps     socat     software-properties-common     util-linux     vim     systemd     systemd-sysv     sysvinit-utils
 ---> Running in 68d6a695d46e
Get:1 http://security-cdn.debian.org/debian-security stretch/updates InRelease [94.3 kB]
Ign:2 http://cdn-fastly.deb.debian.org/debian stretch InRelease
Get:3 http://security-cdn.debian.org/debian-security stretch/updates/main amd64 Packages [591 kB]
Get:4 http://cdn-fastly.deb.debian.org/debian stretch-updates InRelease [91.0 kB]
Get:5 http://cdn-fastly.deb.debian.org/debian stretch Release [118 kB]
Get:6 http://cdn-fastly.deb.debian.org/debian stretch-updates/main amd64 Packages [8410 B]
Get:7 http://cdn-fastly.deb.debian.org/debian stretch Release.gpg [2434 B]
Get:8 http://cdn-fastly.deb.debian.org/debian stretch/main amd64 Packages [9488 kB]
Fetched 10.4 MB in 3s (2736 kB/s)
Reading package lists...
Reading package lists...
Building dependency tree...
Reading state information...
iproute2 is already the newest version (4.9.0-1+deb9u1).
iputils-ping is already the newest version (3:20161105-1).
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 apt-utils : Depends: apt (= 1.4.9) but 1.4.8 is to be installed
E: Unable to correct problems, you have held broken packages.
The command '/bin/sh -c clean-install apt-utils     apt-transport-https     bash     bridge-utils     ca-certificates     curl     e2fsprogs     ebtables     ethtool     gnupg2     ipcalc     iptables     iproute2     iputils-ping     ipset     ipvsadm     jq     kmod     lsb-core     less     lzma     liblz4-tool     mount     net-tools     procps     socat     software-properties-common     util-linux     vim     systemd     systemd-sysv     sysvinit-utils' returned a non-zero code: 100
```

We should update `apt` as well if we want to install `apt-utils` here.