### PR TITLE
Bump k8s versions

### DIFF
--- a/build/buildconf.sh
+++ b/build/buildconf.sh
@@ -1,42 +1,42 @@
-# Version 1.10.11
-KUBEADM_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.11/bin/linux/amd64/kubeadm'
-KUBEADM_SHA1_1_10=d80c4d591ae61f60fb8c22dca2a9ef7dd6412dd9
-HYPERKUBE_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.11/bin/linux/amd64/hyperkube'
-HYPERKUBE_SHA1_1_10=13a9ebddd89332d5937cc9215bd1c446d4e663af
-KUBECTL_LINUX_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.11/bin/linux/amd64/kubectl'
-KUBECTL_LINUX_SHA1_1_10=9ee2f78491cbf8dc76d644c23cfc8c955c34d55d
-KUBECTL_DARWIN_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.11/bin/darwin/amd64/kubectl'
-KUBECTL_DARWIN_SHA1_1_10=1cfafe21222e7f5f809ba4e3e7a1471421998d37
+# Version 1.10.13
+KUBEADM_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubeadm'
+KUBEADM_SHA1_1_10=a577dd72a1a4a1a82468d9ce2375c33e9a8a5adf
+HYPERKUBE_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/hyperkube'
+HYPERKUBE_SHA1_1_10=bb219f362e1e542fef6563c01c6556e55338c61e
+KUBECTL_LINUX_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/linux/amd64/kubectl'
+KUBECTL_LINUX_SHA1_1_10=37c46a35edbe69e28a65a872e735c154402cd4a6
+KUBECTL_DARWIN_URL_1_10='https://storage.googleapis.com/kubernetes-release/release/v1.10.13/bin/darwin/amd64/kubectl'
+KUBECTL_DARWIN_SHA1_1_10=220b0dc38fd7c9a5aeb412589172020b6819e1b3
 
-# Version 1.11.5
-KUBEADM_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.5/bin/linux/amd64/kubeadm'
-KUBEADM_SHA1_1_11=daec1f0ddd654ab2b7553312548e545623037366
-HYPERKUBE_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.5/bin/linux/amd64/hyperkube'
-HYPERKUBE_SHA1_1_11=ddeddb33dfc581bdc3e101d7b17dc1dd2279657f
-KUBECTL_LINUX_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.5/bin/linux/amd64/kubectl'
-KUBECTL_LINUX_SHA1_1_11=feebec8e5649223e586fc45850d8659274c87797
-KUBECTL_DARWIN_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.5/bin/darwin/amd64/kubectl'
-KUBECTL_DARWIN_SHA1_1_11=450e6e17fe65e9d24cbbe39702ad7aa9103662d7
+# Version 1.11.7
+KUBEADM_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubeadm'
+KUBEADM_SHA1_1_11=9a98fff2414f93a93115fb8b304a6bba92e28a60
+HYPERKUBE_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/hyperkube'
+HYPERKUBE_SHA1_1_11=6b027bc6d0c2070ccda0e695880145e189c82f1e
+KUBECTL_LINUX_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/linux/amd64/kubectl'
+KUBECTL_LINUX_SHA1_1_11=142b72418855b985b8a89e81f17df9d5fb88f1a9
+KUBECTL_DARWIN_URL_1_11='https://storage.googleapis.com/kubernetes-release/release/v1.11.7/bin/darwin/amd64/kubectl'
+KUBECTL_DARWIN_SHA1_1_11=9bd37b3eda2fae9f83cc7bcd584216f85ba17304
 
-# Version 1.12.3
-KUBEADM_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubeadm'
-KUBEADM_SHA1_1_12=24d78afbd6bb3dc90cd048a1925eccc7cb4b05db
-HYPERKUBE_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/hyperkube'
-HYPERKUBE_SHA1_1_12=c7ba79dff169b49beff3e8d2943a58adb6bcd7d1
-KUBECTL_LINUX_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/linux/amd64/kubectl'
-KUBECTL_LINUX_SHA1_1_12=4248b9e621af7e902c9d23bf772a2ee8e50146c5
-KUBECTL_DARWIN_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.3/bin/darwin/amd64/kubectl'
-KUBECTL_DARWIN_SHA1_1_12=c7d4086fbdc58d81419f7643304de0bf356e11df
+# Version 1.12.5
+KUBEADM_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.5/bin/linux/amd64/kubeadm'
+KUBEADM_SHA1_1_12=c62767b492bdf98bf90ead913dfad2e94dec80f4
+HYPERKUBE_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.5/bin/linux/amd64/hyperkube'
+HYPERKUBE_SHA1_1_12=26ca10c97011e96e5ca55deae3bce1f829e8d194
+KUBECTL_LINUX_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.5/bin/linux/amd64/kubectl'
+KUBECTL_LINUX_SHA1_1_12=fe8a1096c9a9167725eeb55ade4625b1fc67c270
+KUBECTL_DARWIN_URL_1_12='https://storage.googleapis.com/kubernetes-release/release/v1.12.5/bin/darwin/amd64/kubectl'
+KUBECTL_DARWIN_SHA1_1_12=715663dd9f2e34f2d195bc664174b17f51094740
 
-# Version 1.13.0
-KUBEADM_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubeadm'
-KUBEADM_SHA1_1_13=c40dccc3d6fd0b7a903b0663c7ecd84f37105a2f
-HYPERKUBE_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/hyperkube'
-HYPERKUBE_SHA1_1_13=ce1d5c8a0d0f3afa506f624db7337452ac4c562f
-KUBECTL_LINUX_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/linux/amd64/kubectl'
-KUBECTL_LINUX_SHA1_1_13=5c619006fa45afce6efc51db819aff7d5ba7ef0e
-KUBECTL_DARWIN_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.0/bin/darwin/amd64/kubectl'
-KUBECTL_DARWIN_SHA1_1_13=264df4722e8f70301dd150d455baeae4a855d2fc
+# Version 1.13.3
+KUBEADM_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/kubeadm'
+KUBEADM_SHA1_1_13=a89c340c5128be555d560f6cd18b450030c08f73
+HYPERKUBE_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/hyperkube'
+HYPERKUBE_SHA1_1_13=ce2fdb27fc32a06d8124b7e97cf61c21c1e2f02e
+KUBECTL_LINUX_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/linux/amd64/kubectl'
+KUBECTL_LINUX_SHA1_1_13=6e332647317032e5982db98f4abf80c88c8b3de2
+KUBECTL_DARWIN_URL_1_13='https://storage.googleapis.com/kubernetes-release/release/v1.13.3/bin/darwin/amd64/kubectl'
+KUBECTL_DARWIN_SHA1_1_13=45a1c5037f139af53e00a0c310bf04fa158a862e
 
 # url and sha1sum of hyperkube binary -- only used for prebuilt hyperkube
 KUBEADM_URL=${KUBEADM_URL:-${KUBEADM_URL_1_13}}

--- a/build/genvars.sh
+++ b/build/genvars.sh
@@ -17,7 +17,7 @@ set -o errexit
 set -o nounset
 set -o pipefail
 set -o errtrace
-VERSIONS=(1.10.11 1.11.5 1.12.3 1.13.0)
+VERSIONS=(1.10.13 1.11.7 1.12.5 1.13.3)
 
 first=1
 for version in ${VERSIONS[@]}; do
@@ -35,8 +35,8 @@ for version in ${VERSIONS[@]}; do
   echo "KUBEADM_SHA1_${suffix}=$(curl -sSL "${linux_url}/kubeadm.sha1")"
   echo "HYPERKUBE_URL_${suffix}='${linux_url}/hyperkube'"
   echo "HYPERKUBE_SHA1_${suffix}=$(curl -sSL "${linux_url}/hyperkube.sha1")"
-  echo "KUBECTL_URL_${suffix}='${linux_url}/kubectl'"
-  echo "KUBECTL_SHA1_${suffix}=$(curl -sSL "${linux_url}/kubectl.sha1")"
+  echo "KUBECTL_LINUX_URL_${suffix}='${linux_url}/kubectl'"
+  echo "KUBECTL_LINUX_SHA1_${suffix}=$(curl -sSL "${linux_url}/kubectl.sha1")"
   echo "KUBECTL_DARWIN_URL_${suffix}='${darwin_url}/kubectl'"
   echo "KUBECTL_DARWIN_SHA1_${suffix}=$(curl -sSL "${darwin_url}/kubectl.sha1")"
 done


### PR DESCRIPTION
Use 1.10.13, 1.11.7, 1.12.5 and 1.13.3.