### PR TITLE
Add SKIP_DASHBOARD flag that allows to deploy dashboard optionally

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -525,6 +525,8 @@ DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
 
+SKIP_DASHBOARD="${SKIP_DASHBOARD:-}"
+
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"
 # you can set special value 'none' not to set any kubelet's feature gates.
 KUBELET_FEATURE_GATES="${KUBELET_FEATURE_GATES:-MountPropagation=true,DynamicKubeletConfig=true}"
@@ -1495,6 +1497,36 @@ function dind::ip6tables-on-hostnet {
   docker run -v "${mod_path}:${mod_path}" --entrypoint /sbin/ip6tables --net=host --rm --privileged "${DIND_IMAGE}" "$@"
 }
 
+function dind::component-ready-by-labels {
+  local labels=("$@");
+  for label in ${labels[@]}; do
+    dind::component-ready "${label}" && return 0
+  done
+  return 1
+}
+
+function dind::wait-for-service-ready {
+  local service=$1
+  local labels=("${@:2}")
+  local ctx="$(dind::context-name)"
+
+  dind::step "Bringing up ${service}"
+  # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
+  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system ${service}
+
+  local ntries=200
+  while ! dind::component-ready-by-labels ${labels[@]}; do
+    if ((--ntries == 0)); then
+      echo "Error bringing up ${service}" >&2
+      exit 1
+    fi
+    echo -n "." >&2
+    dind::kill-failed-pods
+    sleep 1
+  done
+  echo "[done]" >&2
+}
+
 function dind::wait-for-ready {
   local app="kube-proxy"
   if [[ ${CNI_PLUGIN} = "kube-router" ]]; then
@@ -1535,28 +1567,22 @@ function dind::wait-for-ready {
     sleep 1
   done
 
-  dind::step "Bringing up ${DNS_SERVICE} and kubernetes-dashboard"
-  # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
-  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system ${DNS_SERVICE}
-  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system kubernetes-dashboard
+  dind::wait-for-service-ready ${DNS_SERVICE} "k8s-app=kube-dns"
 
-  ntries=200
-  while ! dind::component-ready k8s-app=kube-dns || ! dind::component-ready app=kubernetes-dashboard; do
-    if ((--ntries == 0)); then
-      echo "Error bringing up ${DNS_SERVICE} and kubernetes-dashboard" >&2
-      exit 1
-    fi
-    echo -n "." >&2
-    dind::kill-failed-pods
-    sleep 1
-  done
-  echo "[done]" >&2
+  if [[ ! ${SKIP_DASHBOARD} ]]; then
+    local service="kubernetes-dashboard"
+    dind::wait-for-service-ready ${service} "app=${service}" "k8s-app=${service}"
+  fi
 
   dind::retry "${kubectl}" --context "$ctx" get nodes >&2
 
-  local local_host
-  local_host="$( dind::localhost )"
-  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
+  if [[ ! ${SKIP_DASHBOARD} ]]; then
+    local local_host
+    local_host="$( dind::localhost )"
+    local base_url="http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services"
+    dind::step "Access dashboard at:" "${base_url}/kubernetes-dashboard:/proxy"
+    dind::step "Access dashboard at:" "${base_url}/https:kubernetes-dashboard:/proxy (if version>1.6 and HTTPS enabled)"
+  fi
 }
 
 # dind::make-kube-router-yaml creates a temp file with contents of the configuration needed for the kube-router CNI
@@ -1822,7 +1848,11 @@ function dind::up {
       echo "Unsupported CNI plugin '${CNI_PLUGIN}'" >&2
       ;;
   esac
-  dind::deploy-dashboard
+
+  if [[ ! ${SKIP_DASHBOARD} ]]; then
+    dind::deploy-dashboard
+  fi
+
   dind::accelerate-kube-dns
   if [[ (${CNI_PLUGIN} != "bridge" && ${CNI_PLUGIN} != "ptp") || ${SKIP_SNAPSHOT} ]]; then
     # This is especially important in case of Calico -

--- a/fixed/dind-cluster-v1.13.sh
+++ b/fixed/dind-cluster-v1.13.sh
@@ -525,8 +525,6 @@ DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
 
-DIND_SKIP_DASHBOARD="${DIND_SKIP_DASHBOARD:-}"
-
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"
 # you can set special value 'none' not to set any kubelet's feature gates.
 KUBELET_FEATURE_GATES="${KUBELET_FEATURE_GATES:-MountPropagation=true,DynamicKubeletConfig=true}"
@@ -1499,34 +1497,6 @@ function dind::ip6tables-on-hostnet {
   docker run -v "${mod_path}:${mod_path}" --entrypoint /sbin/ip6tables --net=host --rm --privileged "${DIND_IMAGE}" "$@"
 }
 
-function dind::wait-for-service-up {
-  local service=$1
-  local labels=${@:2}
-  local ctx="$(dind::context-name)"
-
-  dind::step "Bringing up ${service}"
-  # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
-  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system ${service}
-
-  local ntries=200 is_ready="" label
-  while true; do
-    for label in ${labels[*]}; do
-      dind::component-ready ${label} && is_ready=1 && break
-    done
-
-    [[ ${is_ready} ]] && break;
-      
-    if ((--ntries == 0)); then
-      echo "Error bringing up ${service}" >&2
-      exit 1
-    fi
-    echo -n "." >&2
-    dind::kill-failed-pods
-    sleep 1
-  done
-  echo "[done]" >&2
-}
-
 function dind::wait-for-ready {
   local app="kube-proxy"
   if [[ ${CNI_PLUGIN} = "kube-router" ]]; then
@@ -1567,21 +1537,28 @@ function dind::wait-for-ready {
     sleep 1
   done
 
-  dind::wait-for-service-up ${DNS_SERVICE} "k8s-app=kube-dns"
+  dind::step "Bringing up ${DNS_SERVICE} and kubernetes-dashboard"
+  # on Travis 'scale' sometimes fails with 'error: Scaling the resource failed with: etcdserver: request timed out; Current resource version 442' here
+  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system ${DNS_SERVICE}
+  dind::retry "${kubectl}" --context "$ctx" scale deployment --replicas=1 -n kube-system kubernetes-dashboard
 
-  if [[ ! ${DIND_SKIP_DASHBOARD} ]]; then
-    dind::wait-for-service-up "kubernetes-dashboard" \
-      "app=kubernetes-dashboard" "k8s-app=kubernetes-dashboard"
-  fi
+  ntries=200
+  while ! dind::component-ready k8s-app=kube-dns || ! dind::component-ready app=kubernetes-dashboard; do
+    if ((--ntries == 0)); then
+      echo "Error bringing up ${DNS_SERVICE} and kubernetes-dashboard" >&2
+      exit 1
+    fi
+    echo -n "." >&2
+    dind::kill-failed-pods
+    sleep 1
+  done
+  echo "[done]" >&2
 
   dind::retry "${kubectl}" --context "$ctx" get nodes >&2
 
-  if [[ ! ${DIND_SKIP_DASHBOARD} ]]; then
-    local local_host="$( dind::localhost )"
-    local base_url="http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services"
-    dind::step "Access dashboard via HTTP  at:" "${base_url}/http:kubernetes-dashboard:/proxy"
-    dind::step "Access dashboard via HTTPs at:" "${base_url}/https:kubernetes-dashboard:/proxy"
-  fi
+  local local_host
+  local_host="$( dind::localhost )"
+  dind::step "Access dashboard at:" "http://${local_host}:$(dind::apiserver-port)/api/v1/namespaces/kube-system/services/kubernetes-dashboard:/proxy"
 }
 
 # dind::make-kube-router-yaml creates a temp file with contents of the configuration needed for the kube-router CNI
@@ -1847,11 +1824,7 @@ function dind::up {
       echo "Unsupported CNI plugin '${CNI_PLUGIN}'" >&2
       ;;
   esac
-
-  if [[ ! ${DIND_SKIP_DASHBOARD} ]]; then
-    dind::deploy-dashboard
-  fi
-
+  dind::deploy-dashboard
   dind::accelerate-kube-dns
   if [[ (${CNI_PLUGIN} != "bridge" && ${CNI_PLUGIN} != "ptp") || ${SKIP_SNAPSHOT} ]]; then
     # This is especially important in case of Calico -

--- a/image/snapshot
+++ b/image/snapshot
@@ -49,17 +49,21 @@ function snapshot::is-service-running {
 
 function snapshot::scale-down-service {
   local service=$1
-  local n=80
-  snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
-  while snapshot::is-service-running ${service}; do
-    if ((--n == 0)); then
-      echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
-      systemctl stop kubelet docker
-      snapshot::clean-containerd
-      return
-    fi
-    sleep 0.3
-  done
+  if snapshot::is-service-running ${service} ; then
+    local n=80
+    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+    while snapshot::is-service-running ${service}; do
+      if ((--n == 0)); then
+        echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
+        systemctl stop kubelet docker
+        snapshot::clean-containerd
+        return
+      fi
+      sleep 0.3
+    done
+  else
+    echo "${service} not found"
+  fi
 }
 
 function snapshot::prepare {
@@ -70,9 +74,7 @@ function snapshot::prepare {
 
     DNS_SERVICE="$(kubectl get deployment -n kube-system -l k8s-app=kube-dns -o name | cut -d / -f 2)"
     snapshot::scale-down-service ${DNS_SERVICE}
-    if snapshot::is-service-running kubernetes-dashboard ; then
-      snapshot::scale-down-service kubernetes-dashboard
-    fi
+    snapshot::scale-down-service kubernetes-dashboard
 
     mkdir /manifests.bak
     # stop controller manager so it doesn't launch new proxy daemon pods

--- a/image/snapshot
+++ b/image/snapshot
@@ -42,6 +42,26 @@ function snapshot::clean-containerd {
   systemctl stop containerd
 }
 
+function snapshot::is-service-running {
+  local service=$1
+  kubectl get pods -n kube-system -o name | egrep -q "^pods*/(${service}-)"
+}
+
+function snapshot::scale-down-service {
+  local service=$1
+  local n=80
+  snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+  while snapshot::is-service-running ${service}; do
+    if ((--n == 0)); then
+      echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
+      systemctl stop kubelet docker
+      snapshot::clean-containerd
+      return
+    fi
+    sleep 0.3
+  done
+}
+
 function snapshot::prepare {
   if [[ -f /etc/kubernetes/manifests/kube-controller-manager.json || -f /etc/kubernetes/manifests/kube-controller-manager.yaml ]]; then
     # remove kube-dns and kube-dashboard pods to avoid 'blinking'
@@ -49,18 +69,10 @@ function snapshot::prepare {
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
 
     DNS_SERVICE="$(kubectl get deployment -n kube-system -l k8s-app=kube-dns -o name | cut -d / -f 2)"
-    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${DNS_SERVICE}
-    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system kubernetes-dashboard
-    local n=80
-    while kubectl get pods -n kube-system -o name | egrep -q "^pods*/(${DNS_SERVICE}-|kubernetes-dashboard-)"; do
-      if ((--n == 0)); then
-        echo "WARNING: controller manager glitch: dns & dashboard won't stop; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker
-        snapshot::clean-containerd
-        return
-      fi
-      sleep 0.3
-    done
+    snapshot::scale-down-service ${DNS_SERVICE}
+    if snapshot::is-service-running kubernetes-dashboard ; then
+      snapshot::scale-down-service kubernetes-dashboard
+    fi
 
     mkdir /manifests.bak
     # stop controller manager so it doesn't launch new proxy daemon pods

--- a/image/snapshot
+++ b/image/snapshot
@@ -49,21 +49,17 @@ function snapshot::is-service-running {
 
 function snapshot::scale-down-service {
   local service=$1
-  if snapshot::is-service-running ${service} ; then
-    local n=80
-    snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
-    while snapshot::is-service-running ${service}; do
-      if ((--n == 0)); then
-        echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
-        systemctl stop kubelet docker
-        snapshot::clean-containerd
-        return
-      fi
-      sleep 0.3
-    done
-  else
-    echo "${service} not found"
-  fi
+  local n=80
+  snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+  while snapshot::is-service-running ${service}; do
+    if ((--n == 0)); then
+      echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
+      systemctl stop kubelet docker
+      snapshot::clean-containerd
+      return
+    fi
+    sleep 0.3
+  done
 }
 
 function snapshot::prepare {
@@ -74,7 +70,11 @@ function snapshot::prepare {
 
     DNS_SERVICE="$(kubectl get deployment -n kube-system -l k8s-app=kube-dns -o name | cut -d / -f 2)"
     snapshot::scale-down-service ${DNS_SERVICE}
-    snapshot::scale-down-service kubernetes-dashboard
+    if snapshot::is-service-running kubernetes-dashboard ; then
+      snapshot::scale-down-service kubernetes-dashboard
+    else
+      echo "${service} not found"
+    fi
 
     mkdir /manifests.bak
     # stop controller manager so it doesn't launch new proxy daemon pods

--- a/image/snapshot
+++ b/image/snapshot
@@ -73,7 +73,7 @@ function snapshot::prepare {
     if snapshot::is-service-running kubernetes-dashboard ; then
       snapshot::scale-down-service kubernetes-dashboard
     else
-      echo "${service} not found"
+      echo "kubernetes-dashboard not found, skipped"
     fi
 
     mkdir /manifests.bak

--- a/image/snapshot
+++ b/image/snapshot
@@ -49,8 +49,8 @@ function snapshot::is-service-running {
 
 function snapshot::scale-down-service {
   local service=$1
-  local n=80
   snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+  local n=80
   while snapshot::is-service-running ${service}; do
     if ((--n == 0)); then
       echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
@@ -73,7 +73,7 @@ function snapshot::prepare {
     if snapshot::is-service-running kubernetes-dashboard ; then
       snapshot::scale-down-service kubernetes-dashboard
     else
-      echo "kubernetes-dashboard not found, skipped"
+      echo "kubernetes-dashboard not found, skip it"
     fi
 
     mkdir /manifests.bak


### PR DESCRIPTION
This PR is for #289 and #65

ChangeLog:
* Add SKIP_DASHBOARD and do not deploy dashboard when it's set to 1. By default, it'll be deployed.
* Break up the code that wait for DNS service and dashboard be ready, and extract the wait-for logic into a util method.
* Support both new and old version of the dashboard where the label is different: `app` for 1.6 vs. `k8s-app` for later version.
* Print Access dashboard info both for HTTP and HTTPs
* Break up the code in `snapshot` to scale down DNS service and dashboard when in prepare method. Only handle dashboard when it's detected to be there.