### PR TITLE
Allow nodes to join custom network(s) during cluster launch

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -524,8 +524,6 @@ DIND_NO_PROXY="${DIND_NO_PROXY:-}"
 DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can be set to /dev/null
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
-# comma-separated custom network(s) for cluster nodes to join
-DIND_CUSTOM_NETWORKS="${DIND_CUSTOM_NETWORKS:-}"
 
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"
 # you can set special value 'none' not to set any kubelet's feature gates.
@@ -1057,14 +1055,6 @@ function dind::run {
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
          ${args[@]+"${args[@]}"}
-
-  if [[ ${DIND_CUSTOM_NETWORKS} ]]; then
-    local cust_nets=
-    local IFS=','; read -ra cust_nets <<< "${DIND_CUSTOM_NETWORKS}"
-    for cust_net in "${cust_nets[@]}"; do
-      docker network connect ${cust_net} ${container_name} >/dev/null
-    done
-  fi
 }
 
 function dind::kubeadm {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -524,6 +524,8 @@ DIND_NO_PROXY="${DIND_NO_PROXY:-}"
 DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can be set to /dev/null
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
+# comma-separated custom network(s) for cluster nodes to join
+DIND_CUSTOM_NETWORKS="${DIND_CUSTOM_NETWORKS:-}"
 
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"
 # you can set special value 'none' not to set any kubelet's feature gates.
@@ -1055,6 +1057,14 @@ function dind::run {
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
          ${args[@]+"${args[@]}"}
+
+  if [[ ${DIND_CUSTOM_NETWORKS} ]]; then
+    local cust_nets=
+    local IFS=','; read -ra cust_nets <<< "${DIND_CUSTOM_NETWORKS}"
+    for cust_net in "${cust_nets[@]}"; do
+      docker network connect ${cust_net} ${container_name} >/dev/null
+    done
+  fi
 }
 
 function dind::kubeadm {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -524,6 +524,8 @@ DIND_NO_PROXY="${DIND_NO_PROXY:-}"
 DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can be set to /dev/null
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
+# comma-separated custom networks for cluster nodes to join
+DIND_CUSTOM_NETWORKS="${DIND_CUSTOM_NETWORKS:-}"
 
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"
 # you can set special value 'none' not to set any kubelet's feature gates.
@@ -1055,6 +1057,14 @@ function dind::run {
          ${opts[@]+"${opts[@]}"} \
          "${DIND_IMAGE}" \
          ${args[@]+"${args[@]}"}
+
+  if [[ ${DIND_CUSTOM_NETWORKS} ]]; then
+    local cust_nets=
+    local IFS=','; read -ra cust_nets <<< "${DIND_CUSTOM_NETWORKS}"
+    for cust_net in "${cust_nets[@]}"; do
+      docker network connect ${cust_net} ${container_name} >/dev/null
+    done
+  fi
 }
 
 function dind::kubeadm {

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -524,7 +524,7 @@ DIND_NO_PROXY="${DIND_NO_PROXY:-}"
 DIND_DAEMON_JSON_FILE="${DIND_DAEMON_JSON_FILE:-/etc/docker/daemon.json}"  # can be set to /dev/null
 DIND_REGISTRY_MIRROR="${DIND_REGISTRY_MIRROR:-}"  # plain string format
 DIND_INSECURE_REGISTRIES="${DIND_INSECURE_REGISTRIES:-}"  # json list format
-# comma-separated custom networks for cluster nodes to join
+# comma-separated custom network(s) for cluster nodes to join
 DIND_CUSTOM_NETWORKS="${DIND_CUSTOM_NETWORKS:-}"
 
 FEATURE_GATES="${FEATURE_GATES:-MountPropagation=true}"

--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1059,7 +1059,7 @@ function dind::run {
          ${args[@]+"${args[@]}"}
 
   if [[ ${DIND_CUSTOM_NETWORKS} ]]; then
-    local cust_nets=
+    local cust_nets
     local IFS=','; read -ra cust_nets <<< "${DIND_CUSTOM_NETWORKS}"
     for cust_net in "${cust_nets[@]}"; do
       docker network connect ${cust_net} ${container_name} >/dev/null


### PR DESCRIPTION
This PR is for #295 

ChangeLog:
* Add `DIND_CUSTOM_NETWORKS` flag that allows people to specify comma-separated custom networks, typically the user-defined Docker bridge networks.
* Run `docker network connect` right after each containerized cluster node is launched if `DIND_CUSTOM_NETWORKS` is specified.