### PR TITLE
fix: dind-cluster script pattern match comparison failures

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1097,7 +1097,7 @@ function dind::configure-kubectl {
     --server="http://${host}:$(dind::apiserver-port)" \
     --insecure-skip-tls-verify=true
   "${kubectl}" config set-context "$context_name" --cluster="$cluster_name"
-  if [[ ${DIND_LABEL} = ${DEFAULT_DIND_LABEL} ]]; then
+  if [[ ${DIND_LABEL} = "${DEFAULT_DIND_LABEL}" ]]; then
       # Single cluster mode
       "${kubectl}" config use-context "$context_name"
   fi


### PR DESCRIPTION
this PR changes a pattern-match based comparison of variables to a string-based comparison. this resolves issues with use of kubeadm-dind within e.g. travis

Fixes #292