### PR TITLE
Fix the test_src_master build failure

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -1322,7 +1322,7 @@ EOF
   if [[ ${BUILD_KUBEADM} || ${BUILD_HYPERKUBE} ]]; then
     docker exec "$master_name" mount --make-shared /k8s
   fi
-  kubeadm_join_flags="$(dind::kubeadm "${container_id}" init "${init_args[@]}" --ignore-preflight-errors=all "$@" | grep 'kubeadm join.*--token' | tail -1 | sed 's/^.*kubeadm join //')"
+  kubeadm_join_flags="$(dind::kubeadm "${container_id}" init "${init_args[@]}" --ignore-preflight-errors=all "$@" | grep -A1 'kubeadm join.*--token' | sed 's/^.*kubeadm join //; s/\\$//; N; s/\n//')"
   dind::configure-kubectl
   dind::start-port-forwarder
 }

--- a/image/snapshot
+++ b/image/snapshot
@@ -42,18 +42,28 @@ function snapshot::clean-containerd {
   systemctl stop containerd
 }
 
+function snapshot::text_join {
+  local IFS="$1"; shift; echo "$*"
+}
+
 function snapshot::is-service-running {
-  local service=$1
-  kubectl get pods -n kube-system -o name | egrep -q "^pods*/(${service}-)"
+  kubectl get pods -n kube-system -o name | egrep -q "^pods*/($(snapshot::text_join '|' ${@/%/-}))"
 }
 
 function snapshot::scale-down-service {
-  local service=$1
-  snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+  local service
+  for service in "$@"; do
+    if snapshot::is-service-running ${service} ; then
+      snapshot::retry kubectl scale deployment --replicas=0 -n kube-system ${service}
+    else
+      echo "${service} not found, skip it"
+    fi
+  done
+
   local n=80
-  while snapshot::is-service-running ${service}; do
+  while snapshot::is-service-running $@; do
     if ((--n == 0)); then
-      echo "WARNING: controller manager glitch: ${service} won't stop; pods may 'blink' for some time after restore" >&2
+      echo "WARNING: controller manager glitch: $(snapshot::text_join '&' $@) won't stop; pods may 'blink' for some time after restore" >&2
       systemctl stop kubelet docker
       snapshot::clean-containerd
       return
@@ -69,12 +79,7 @@ function snapshot::prepare {
     # Possibly related: https://github.com/kubernetes/kubernetes/issues/42685
 
     DNS_SERVICE="$(kubectl get deployment -n kube-system -l k8s-app=kube-dns -o name | cut -d / -f 2)"
-    snapshot::scale-down-service ${DNS_SERVICE}
-    if snapshot::is-service-running kubernetes-dashboard ; then
-      snapshot::scale-down-service kubernetes-dashboard
-    else
-      echo "kubernetes-dashboard not found, skip it"
-    fi
+    snapshot::scale-down-service ${DNS_SERVICE} kubernetes-dashboard
 
     mkdir /manifests.bak
     # stop controller manager so it doesn't launch new proxy daemon pods


### PR DESCRIPTION
This is to fix the issue #299 

ChangeLog:
* Update the code to grab the join flags from kubeadm output according to the latest change introduced into Kubernetes source.

The original line was split into two by the author,  so that it needs to grab both the line matched and the line right after that. Also, it needs to drop the trailing backslash and carriage return.

P.S.
Although the approach to grab is improved here, and I did test some other possible variant outputs, it appears to me that to use grep/sed to grab the flags from the output is generally unreliable. Also, it depends on how often the output of these flags are changed :-)