### PR TITLE
Fixing linuxkit detection on the latest versions of Docker for Mac

### DIFF
--- a/dind-cluster.sh
+++ b/dind-cluster.sh
@@ -24,8 +24,10 @@ else
 fi
 DIND_ROOT="$(cd $(dirname "$(readlinkf "${BASH_SOURCE}")"); pwd)"
 
+docker_info_output="$(docker info)"
+
 RUN_ON_BTRFS_ANYWAY="${RUN_ON_BTRFS_ANYWAY:-}"
-if [[ ! ${RUN_ON_BTRFS_ANYWAY} ]] && docker info| grep -q '^Storage Driver: btrfs'; then
+if [[ ! ${RUN_ON_BTRFS_ANYWAY} ]] && echo "$docker_info_output"| grep -q '^ *Storage Driver: btrfs'; then
   echo "ERROR: Docker is using btrfs storage driver which is unsupported by kubeadm-dind-cluster" >&2
   echo "Please refer to the documentation for more info." >&2
   echo "Set RUN_ON_BTRFS_ANYWAY to non-empty string to continue anyway." >&2
@@ -36,9 +38,9 @@ fi
 # mount /lib/modules and /boot. Also we'll be using localhost
 # to access the apiserver.
 using_linuxkit=
-if ! docker info|grep -s '^Operating System: .*Docker for Windows' > /dev/null 2>&1 ; then
-    if docker info|grep -s '^Kernel Version: .*-moby$' >/dev/null 2>&1 ||
-         docker info|grep -s '^Kernel Version: .*-linuxkit' > /dev/null 2>&1 ; then
+if ! echo "$docker_info_output"|grep -s '^ *Operating System: .*Docker for Windows' > /dev/null 2>&1 ; then
+    if echo "$docker_info_output"|grep -s '^ *Kernel Version: .*-moby$' >/dev/null 2>&1 ||
+         echo "$docker_info_output"|grep -s '^ *Kernel Version: .*-linuxkit' > /dev/null 2>&1 ; then
         using_linuxkit=1
     fi
 fi

--- a/test/test-multiple-clusters.sh
+++ b/test/test-multiple-clusters.sh
@@ -155,9 +155,11 @@ function countContainersWithFilter() {
 }
 
 function usesLinuxKit() {
-  if ! docker info|grep -s '^Operating System: .*Docker for Windows' > /dev/null 2>&1 ; then
-    if docker info|grep -s '^Kernel Version: .*-moby$' >/dev/null 2>&1 ||
-        docker info|grep -s '^Kernel Version: .*-linuxkit' > /dev/null 2>&1 ; then
+  local docker_info_output
+  docker_info_output="$(docker info)" || return $?
+  if ! echo "$docker_info_output"|grep -s '^ *Operating System: .*Docker for Windows' > /dev/null 2>&1 ; then
+    if echo "$docker_info_output"|grep -s '^ *Kernel Version: .*-moby$' >/dev/null 2>&1 ||
+        echo "$docker_info_output"|grep -s '^ *Kernel Version: .*-linuxkit' > /dev/null 2>&1 ; then
       return 0
     fi
   fi


### PR DESCRIPTION
Recent versions of Docker can have leading spaces in the output of
`docker info`, which the regexes used to detect linuxkit didn't account
for. Fixing that, and also consolidated the calls to `docker info` as it
can take half a second every time to return.

Signed-off-by: Jean Rouge <rougej+github@gmail.com>